### PR TITLE
Ensuring consistent CompositeDisposable invariant

### DIFF
--- a/Rx.NET/Source/System.Reactive.Core/Reactive/Disposables/CompositeDisposable.cs
+++ b/Rx.NET/Source/System.Reactive.Core/Reactive/Disposables/CompositeDisposable.cs
@@ -48,6 +48,8 @@ namespace System.Reactive.Disposables
         {
             if (disposables == null)
                 throw new ArgumentNullException("disposables");
+            if (disposables.Any(d => d == null))
+                throw new ArgumentException("disposables collection can not contain null values.", "disposables");
 
             _disposables = new List<IDisposable>(disposables);
             _count = _disposables.Count;
@@ -62,6 +64,8 @@ namespace System.Reactive.Disposables
         {
             if (disposables == null)
                 throw new ArgumentNullException("disposables");
+            if(disposables.Any(d=>d==null))
+                throw new ArgumentException("disposables collection can not contain null values.", "disposables");
 
             _disposables = new List<IDisposable>(disposables);
             _count = _disposables.Count;

--- a/Rx.NET/Source/Tests.System.Reactive/Tests/Disposables/DisposableTests.cs
+++ b/Rx.NET/Source/Tests.System.Reactive/Tests/Disposables/DisposableTests.cs
@@ -224,6 +224,20 @@ namespace ReactiveTests.Tests
             Assert.IsTrue(g.Contains(d2));
         }
 
+        [TestMethod, ExpectedException(typeof(ArgumentException))]
+        public void CompositeDisposable_AddNull_via_params_ctor()
+        {
+            IDisposable d1 = null;
+            new CompositeDisposable(d1);
+        }
+        [TestMethod, ExpectedException(typeof(ArgumentException))]
+        public void CompositeDisposable_AddNull_via_IEnum_ctor()
+        {
+            IEnumerable<IDisposable> values = new IDisposable[] { null };
+            new CompositeDisposable(values);
+        }
+
+
         [TestMethod, ExpectedException(typeof(ArgumentNullException))]
         public void CompositeDisposable_AddNull()
         {


### PR DESCRIPTION
This pull request enforces that null values can not be added to the CompositeDisposable type via the constructors. Closes issue #73