### PR TITLE
Bug in async Observable.Create fixes #83

### DIFF
--- a/Rx.NET/Source/System.Reactive.Linq/Reactive/Linq/QueryLanguage.Creation.cs
+++ b/Rx.NET/Source/System.Reactive.Linq/Reactive/Linq/QueryLanguage.Creation.cs
@@ -47,7 +47,7 @@ namespace System.Reactive.Linq
                 var cancellable = new CancellationDisposable();
 
                 var taskObservable = subscribeAsync(observer, cancellable.Token).ToObservable();
-                var taskCompletionObserver = new AnonymousObserver<Unit>(Stubs<Unit>.Ignore, observer.OnError, observer.OnCompleted);
+                var taskCompletionObserver = new AnonymousObserver<Unit>(Stubs<Unit>.Ignore, observer.OnError, Stubs.Nop);
                 var subscription = taskObservable.Subscribe(taskCompletionObserver);
 
                 return new CompositeDisposable(cancellable, subscription);


### PR DESCRIPTION
This PR fixes a problem where the completion of an asynchronous subscription that does not return a disposable or action incorrectly triggers a call to `OnCompleted` on the observer. See the following repro:

```C#
var normalObs = Observable.Create<int>(async o => {
    await Task.FromResult(0);
    o.OnNext(1);
    o.OnCompleted();
});
        
normalObs.Subscribe(Console.WriteLine, () => Console.WriteLine("Done"));
```
This outputs an erroneous "Done" due to this problem:

```
Done
1
Done
```

Thanks to @Lukazoid for spotting the inconsistency. See [issue 83](https://github.com/Reactive-Extensions/Rx.NET/issues/83) for more.