### PR TITLE
Fix #93

### DIFF
--- a/Ix.NET/Source/System.Interactive.Async/Disposables.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Disposables.cs
@@ -51,7 +51,7 @@ namespace System.Linq
 
                     _disposable = value;
 
-                    if (_disposed)
+                    if ((_disposable != null) && (_disposed))
                         _disposable.Dispose();
                 }
             }


### PR DESCRIPTION
This fixes AsyncEnumerable.SelectMany. The sequence of inner IAsyncEnumerators is represented through an AssignableDisposable (equivalent to SerialDisposable from Rx). This takes care that the previous inner IAsyncEnumerator is properly disposed when a new one is assigned, and each inner IAsyncEnumerator is disposed only once.