### PR TITLE
Add Disposable.Compose()

### DIFF
--- a/Rx.NET/Source/System.Reactive.Core/Reactive/Disposables/Disposable.cs
+++ b/Rx.NET/Source/System.Reactive.Core/Reactive/Disposables/Disposable.cs
@@ -28,5 +28,25 @@ namespace System.Reactive.Disposables
 
             return new AnonymousDisposable(dispose);
         }
+
+        /// <summary>
+        /// Creates a disposable object that disposes the specified disposables.
+        /// </summary>
+        /// <param name="disposables">Disposables that will be disposed together.</param>
+        /// <returns>The disposable object that disposes the specified disposables.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="disposables"/> is null.</exception>
+        public static IDisposable Compose(params IDisposable[] disposables)
+        {
+            if (disposables == null)
+                throw new ArgumentNullException("disposables");
+
+            return Disposable.Create(() => 
+                {
+                    foreach (var disposable in disposables) 
+                    { 
+                        disposable.Dispose(); 
+                    }
+                });
+        } 
     }
 }


### PR DESCRIPTION
I've added this static method to several projects i've worked on. I prefer it over using CompositeDisposable as its more functional in nature, and I've never needed the ability to add/remove disposables. Thoughts? 