### PR TITLE
ToObservable: Do not call MoveNext with an already canceled CancellationToken

### DIFF
--- a/Ix.NET/Source/System.Interactive.Async/ToObservable.cs
+++ b/Ix.NET/Source/System.Interactive.Async/ToObservable.cs
@@ -202,7 +202,13 @@ namespace System.Linq
                                                  if (t.Result)
                                                  {
                                                      observer.OnNext(e.Current);
-                                                     f();
+
+                                                     if (!ctd.Token.IsCancellationRequested)
+                                                         f();
+                                                     
+                                                     //In case cancellation is requested, this could only have happened
+                                                     //by disposing the returned composite disposable (see below).
+                                                     //In that case, e will be disposed too, so there is no need to dispose e here.
                                                  }
                                                  else
                                                  {


### PR DESCRIPTION
This would happen whenever an IObserver<T>.OnNext would dispose its subscription within a call to OnNext. The built in AnonymousAsyncEnumerator<T> checks whether it's already disposed, however, not every user code might handle canceled tokens that gracefully. Also, the continuation of MoveNext will not be scheduled anyway.

