### PR TITLE
This includes two fixes for 1)TakeLast(0) take infinite time to return. 2)https://github.com/aspnet/EntityFramework/issues/2192

### DIFF
--- a/Ix.NET/Source/System.Interactive.Async/AsyncEnumerable.Single.cs
+++ b/Ix.NET/Source/System.Interactive.Async/AsyncEnumerable.Single.cs
@@ -51,7 +51,7 @@ namespace System.Linq
                                 }
                             });
                         });
-                        
+
                         return tcs.Task.UsingEnumerator(e);
                     },
                     () => current,
@@ -1175,7 +1175,7 @@ namespace System.Linq
             return Create(() =>
             {
                 var gate = new object();
-                
+
                 var e = source.GetEnumerator();
                 var count = 1;
 
@@ -1332,7 +1332,7 @@ namespace System.Linq
                 throw new ArgumentNullException("keySelector");
             if (elementSelector == null)
                 throw new ArgumentNullException("elementSelector");
-            
+
             return source.GroupBy(keySelector, elementSelector, EqualityComparer<TKey>.Default);
         }
 
@@ -1354,7 +1354,7 @@ namespace System.Linq
                 throw new ArgumentNullException("source");
             if (keySelector == null)
                 throw new ArgumentNullException("keySelector");
-            
+
             return source.GroupBy(keySelector, x => x, EqualityComparer<TKey>.Default);
         }
 
@@ -1410,7 +1410,7 @@ namespace System.Linq
                 throw new ArgumentNullException("keySelector");
             if (resultSelector == null)
                 throw new ArgumentNullException("resultSelector");
-            
+
             return source.GroupBy(keySelector, x => x, EqualityComparer<TKey>.Default).Select(g => resultSelector(g.Key, g));
         }
 
@@ -2372,12 +2372,14 @@ namespace System.Linq
                             t.Handle(tcs, res =>
                             {
                                 if (res)
-                                {
-                                    var item = e.Current;
-
-                                    if (q.Count >= count)
-                                        q.Dequeue();
-                                    q.Enqueue(item);
+                                {                                    
+                                    if (count > 0)
+                                    {
+                                        var item = e.Current;
+                                        if (q.Count >= count)
+                                            q.Dequeue();
+                                        q.Enqueue(item);
+                                    }
                                 }
                                 else
                                 {

--- a/Ix.NET/Source/System.Interactive.Async/TaskExt.cs
+++ b/Ix.NET/Source/System.Interactive.Async/TaskExt.cs
@@ -33,7 +33,7 @@ namespace System.Threading.Tasks
         public static void Handle<T, R>(this Task<T> task, TaskCompletionSource<R> tcs, Action<T> success)
         {
             if (task.IsFaulted)
-                tcs.TrySetException(task.Exception);
+                tcs.TrySetException(task.Exception.InnerExceptions);
             else if (task.IsCanceled)
                 tcs.TrySetCanceled();
             else if (task.IsCompleted)

--- a/Ix.NET/Source/System.Interactive/EnumerableEx.Single.cs
+++ b/Ix.NET/Source/System.Interactive/EnumerableEx.Single.cs
@@ -582,6 +582,11 @@ namespace System.Linq
 
         private static IEnumerable<TSource> TakeLast_<TSource>(this IEnumerable<TSource> source, int count)
         {
+            if (count == 0)
+            {
+                yield break;
+            }
+
             var q = new Queue<TSource>(count);
 
             foreach (var item in source)

--- a/Ix.NET/Source/Tests/AsyncTests.Single.cs
+++ b/Ix.NET/Source/Tests/AsyncTests.Single.cs
@@ -2424,6 +2424,24 @@ namespace Tests
         }
 
         [TestMethod]
+        public void TakeLast_BugFix_TakeLast_Zero_TakesForever()
+        {
+            bool isSet = false;
+            new int[] { 1, 2, 3, 4 }.ToAsyncEnumerable()
+                .TakeLast(0)
+                .ForEachAsync(_ => { isSet = true; })
+                .Wait();
+
+            Assert.IsFalse(isSet);
+
+            var xs = new[] { 1, 2, 3, 4 }.ToAsyncEnumerable().TakeLast(0);
+
+            var e = xs.GetEnumerator();
+            
+            NoNext(e);
+        }
+
+        [TestMethod]
         public void SkipLast_Null()
         {
             AssertThrows<ArgumentNullException>(() => AsyncEnumerable.SkipLast(default(IAsyncEnumerable<int>), 5));

--- a/Ix.NET/Source/Tests/TaskExtTests.cs
+++ b/Ix.NET/Source/Tests/TaskExtTests.cs
@@ -1,0 +1,52 @@
+﻿namespace Tests
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+
+    public partial class AsyncTests
+    {
+        [TestMethod]
+        public async Task ExceptionHandling_ShouldThrowUnwrappedException()
+        {
+            try
+            {
+                var asyncEnumerable = AsyncEnumerable.ToAsyncEnumerable(GetEnumerableWithError());
+                await asyncEnumerable.ToArray();
+            }
+            catch (AggregateException)
+            {
+                Assert.Fail("AggregateException has been thrown instead of InvalidOperationException");
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
+
+        private IEnumerable<int> GetEnumerableWithError()
+        {
+            yield return 5;
+            throw new InvalidOperationException();
+        }
+
+        [TestMethod]
+        public async Task ExceptionHandling_ShouldThrowUnwrappedException2()
+        {
+            try
+            {
+                var asyncEnumerable = AsyncEnumerable.Generate(15, (x) => { throw new InvalidOperationException(); }, (x) => { return 20; }, (x) => { return 2; });
+                await asyncEnumerable.ToArray();
+            }
+            catch (AggregateException)
+            {
+                Assert.Fail("AggregateException has been thrown instead of InvalidOperationException");
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        }
+    }
+}
+

--- a/Ix.NET/Source/Tests/Tests.Single.cs
+++ b/Ix.NET/Source/Tests/Tests.Single.cs
@@ -351,6 +351,14 @@ namespace Tests
         }
 
         [TestMethod]
+        public void TakeLast_TakeZero()
+        {
+            var e = Enumerable.Range(1, 5) ;
+            var r = e.TakeLast(0).ToList();
+            Assert.IsTrue(Enumerable.SequenceEqual(r, Enumerable.Empty<int>()));
+        }
+
+        [TestMethod]
         public void TakeLast_Empty()
         {
             var e = Enumerable.Empty<int>();

--- a/Ix.NET/Source/Tests/Tests.csproj
+++ b/Ix.NET/Source/Tests/Tests.csproj
@@ -76,6 +76,7 @@
     <Compile Include="AsyncTests.Aggregates.cs" />
     <Compile Include="AsyncTests.Bugs.cs" />
     <Compile Include="AsyncTests.Exceptions.cs" />
+    <Compile Include="TaskExtTests.cs" />
     <Compile Include="Tests.Imperative.cs" />
     <Compile Include="Tests.Qbservable.cs" />
     <Compile Include="Tests.Single.cs" />


### PR DESCRIPTION
1. AsyncEnumerable. TakeLast(0) takes forever to return.
new int[] { 1 }.ToAsyncEnumerable().TakeLast(0).ForEachAsync(_ => { }).Wait()
2. AsyncEnumerable Task extension class method throws wrapped AggregatedException which is not useful if someone wants to understand root cause of the problem.
 See the enitre thread here - https://github.com/aspnet/EntityFramework/issues/2192