### PR TITLE
Fix unit tests for Ix.Net build.

### DIFF
--- a/Ix.NET/Source/Tests/AssertEx.cs
+++ b/Ix.NET/Source/Tests/AssertEx.cs
@@ -35,12 +35,18 @@ namespace Tests
         {
             try
             {
-                action();   
+                action();
             }
+#if !NO_TPL
             catch (AggregateException ex)
             {
                 var inner = ex.Flatten().InnerException;
 
+                // TODO: proper assert; unfortunately there's not always a good call stack
+            }
+#endif
+            catch (Exception)
+            {
                 // TODO: proper assert; unfortunately there's not always a good call stack
             }
         }

--- a/Ix.NET/Source/Tests/AssertEx.cs
+++ b/Ix.NET/Source/Tests/AssertEx.cs
@@ -44,11 +44,12 @@ namespace Tests
 
                 // TODO: proper assert; unfortunately there's not always a good call stack
             }
-#endif
+#else
             catch (Exception)
             {
                 // TODO: proper assert; unfortunately there's not always a good call stack
             }
+#endif
         }
     }
 }

--- a/Ix.NET/Source/Tests/AsyncQueryableTests.Generated.cs
+++ b/Ix.NET/Source/Tests/AsyncQueryableTests.Generated.cs
@@ -1,5 +1,4 @@
-﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
-#if !SILVERLIGHTM7 && !PORTABLE && !NO_RXINTERFACES
+﻿#if !SILVERLIGHTM7 && !PORTABLE && !NO_RXINTERFACES 
 
 using System;
 using System.Collections.Generic;
@@ -3039,9 +3038,8 @@ namespace Tests
 			AssertEx.Throws<ArgumentNullException>(() => AsyncQueryable.TakeLast<int>(default(IAsyncQueryable<int>), 1), ane => ane.ParamName == "source");
 
 			var res = AsyncQueryable.TakeLast<int>(new int[] { default(int) }.ToAsyncEnumerable().AsAsyncQueryable(), 1);
-            var task = res.ForEachAsync(_ => { });
-            AssertEx.SucceedOrFailProper(() => task.Wait());
-        }
+			// TODO: investigate test hang
+		}
 
 		[TestMethod]
 		public void TakeWhile1()

--- a/Ix.NET/Source/Tests/AsyncQueryableTests.Generated.cs
+++ b/Ix.NET/Source/Tests/AsyncQueryableTests.Generated.cs
@@ -1,4 +1,5 @@
-﻿#if !SILVERLIGHTM7 && !PORTABLE && !NO_RXINTERFACES 
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+#if !SILVERLIGHTM7 && !PORTABLE && !NO_RXINTERFACES 
 
 using System;
 using System.Collections.Generic;
@@ -3037,7 +3038,9 @@ namespace Tests
 		{
 			AssertEx.Throws<ArgumentNullException>(() => AsyncQueryable.TakeLast<int>(default(IAsyncQueryable<int>), 1), ane => ane.ParamName == "source");
 
-			var res = AsyncQueryable.TakeLast<int>(new int[] { default(int) }.ToAsyncEnumerable().AsAsyncQueryable(), 1);			
+			var res = AsyncQueryable.TakeLast<int>(new int[] { default(int) }.ToAsyncEnumerable().AsAsyncQueryable(), 1);
+			var task = res.ForEachAsync(_ => { });
+			AssertEx.SucceedOrFailProper(() => task.Wait());
 		}
 
 		[TestMethod]

--- a/Ix.NET/Source/Tests/AsyncQueryableTests.Generated.cs
+++ b/Ix.NET/Source/Tests/AsyncQueryableTests.Generated.cs
@@ -1,5 +1,5 @@
 ﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
-#if !SILVERLIGHTM7 && !PORTABLE
+#if !SILVERLIGHTM7 && !PORTABLE && !NO_RXINTERFACES
 
 using System;
 using System.Collections.Generic;

--- a/Ix.NET/Source/Tests/AsyncQueryableTests.Generated.cs
+++ b/Ix.NET/Source/Tests/AsyncQueryableTests.Generated.cs
@@ -3037,8 +3037,7 @@ namespace Tests
 		{
 			AssertEx.Throws<ArgumentNullException>(() => AsyncQueryable.TakeLast<int>(default(IAsyncQueryable<int>), 1), ane => ane.ParamName == "source");
 
-			var res = AsyncQueryable.TakeLast<int>(new int[] { default(int) }.ToAsyncEnumerable().AsAsyncQueryable(), 1);
-			// TODO: investigate test hang
+			var res = AsyncQueryable.TakeLast<int>(new int[] { default(int) }.ToAsyncEnumerable().AsAsyncQueryable(), 1);			
 		}
 
 		[TestMethod]

--- a/Ix.NET/Source/Tests/AsyncQueryableTests.Generated.tt
+++ b/Ix.NET/Source/Tests/AsyncQueryableTests.Generated.tt
@@ -8,7 +8,6 @@
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".cs" #>
 <#
-
 var failing = new[] { "TakeLast" };
 var exclude = new[] { "ForEach", "ForEachAsync", "ToEnumerable", "ToAsyncEnumerable", "ToObservable", "AsAsyncEnumerable" };
 

--- a/Ix.NET/Source/Tests/AsyncQueryableTests.Generated.tt
+++ b/Ix.NET/Source/Tests/AsyncQueryableTests.Generated.tt
@@ -1,4 +1,5 @@
-﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+<#@ template debug="false" hostspecific="false" language="C#" #>
 <#@ assembly name="System.Core" #>
 <#@ assembly name="$(ProjectDir)\..\packages\Ix-Async.1.2.5\lib\net45\System.Interactive.Async.dll" #>
 <#@ import namespace="System.Linq" #>
@@ -8,7 +9,7 @@
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".cs" #>
 <#
-var failing = new[] { "TakeLast" };
+var failing = new string[] {  };
 var exclude = new[] { "ForEach", "ForEachAsync", "ToEnumerable", "ToAsyncEnumerable", "ToObservable", "AsAsyncEnumerable" };
 
 var toQuotedImpl = default(Func<Type, int, bool, string>);

--- a/Ix.NET/Source/Tests/AsyncQueryableTests.Generated.tt
+++ b/Ix.NET/Source/Tests/AsyncQueryableTests.Generated.tt
@@ -8,6 +8,7 @@
 <#@ import namespace="System.Collections.Generic" #>
 <#@ output extension=".cs" #>
 <#
+
 var failing = new[] { "TakeLast" };
 var exclude = new[] { "ForEach", "ForEachAsync", "ToEnumerable", "ToAsyncEnumerable", "ToObservable", "AsAsyncEnumerable" };
 
@@ -98,6 +99,8 @@ var toQuoted = new Func<Type, int, string>((t, i) => toQuotedImpl(t, i, true));
 
 var index = new Dictionary<string, int>();
 #>
+#if !SILVERLIGHTM7 && !PORTABLE && !NO_RXINTERFACES 
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -472,3 +475,4 @@ if (indexes.Count != 0)
 #>
 	}
 }
+#endif

--- a/Ix.NET/Source/Tests/NopObserver.cs
+++ b/Ix.NET/Source/Tests/NopObserver.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿#if !NO_RXINTERFACES
+using System;
 
 namespace Tests
 {
@@ -17,3 +18,4 @@ namespace Tests
         }
     }
 }
+#endif

--- a/Ix.NET/Source/Tests/NopObserver.cs
+++ b/Ix.NET/Source/Tests/NopObserver.cs
@@ -1,4 +1,5 @@
-﻿#if !NO_RXINTERFACES
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+#if !NO_RXINTERFACES
 using System;
 
 namespace Tests

--- a/Ix.NET/Source/Tests/TaskExtTests.cs
+++ b/Ix.NET/Source/Tests/TaskExtTests.cs
@@ -1,18 +1,19 @@
-﻿namespace Tests
-{
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading.Tasks;
+﻿#if HAS_AWAIT
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
 
+namespace Tests
+{
     public partial class AsyncTests
     {
         [TestMethod]
         public async Task ExceptionHandling_ShouldThrowUnwrappedException()
         {
             try
-            {
+            {                
                 var asyncEnumerable = AsyncEnumerable.ToAsyncEnumerable(GetEnumerableWithError());
                 await asyncEnumerable.ToArray();
             }
@@ -49,4 +50,4 @@
         }
     }
 }
-
+#endif

--- a/Ix.NET/Source/Tests/TaskExtTests.cs
+++ b/Ix.NET/Source/Tests/TaskExtTests.cs
@@ -1,4 +1,5 @@
-﻿#if HAS_AWAIT
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+#if HAS_AWAIT
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;


### PR DESCRIPTION
Ix.Net build unit tests are failing for various reasons (mostly for ReleasePL|AnyCPU flavor). Fixed all the issues in multiple commits.