### PR TITLE
[WIP] Ported core projects to project.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,9 @@ ClientBin
 stylecop.*
 ~$*
 *.dbmdl
+.vs/
+project.lock.json
+artifacts/
 Generated_Code #added for RIA/Silverlight projects
 
 # Backup & report files from converting an old project file to a newer

--- a/Rx.NET/Source/Rx-New.sln
+++ b/Rx.NET/Source/Rx-New.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25008.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "System.Reactive.Core", "System.Reactive.Core\System.Reactive.Core.xproj", "{FDA62C35-4174-44B0-BEBE-61E80B2515BA}"
 EndProject
@@ -9,6 +9,22 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "System.Reactive.Linq", "System.Reactive.Linq\System.Reactive.Linq.xproj", "{A5508FF0-93B9-4241-B666-07B05189C435}"
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "System.Reactive.PlatformServices", "System.Reactive.PlatformServices\System.Reactive.PlatformServices.xproj", "{7DD3DDA0-0B73-4A7F-ACAF-15111AC2EB93}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "System.Reactive.Observable.Aliases", "System.Reactive.Observable.Aliases\System.Reactive.Observable.Aliases.xproj", "{5965A929-C3E5-42AD-8328-3641F8967E72}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "System.Reactive.Providers", "System.Reactive.Providers\System.Reactive.Providers.xproj", "{845E4FBF-A6C0-4870-9D1A-C832E262D956}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "System.Reactive.Experimental", "System.Reactive.Experimental\System.Reactive.Experimental.xproj", "{FB2DB31D-FCFA-45CE-A3A8-7B7C14ECD77A}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "System.Reactive.Windows.Threading", "System.Reactive.Windows.Threading\System.Reactive.Windows.Threading.xproj", "{C18C6FE5-7408-4F3B-B562-7A563E01701E}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "System.Reactive.Runtime.Remoting", "System.Reactive.Runtime.Remoting\System.Reactive.Runtime.Remoting.xproj", "{A22F3131-6D20-4D67-9A9F-314FE3691EA1}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core", "Core", "{0410EFCB-757C-46BA-99AA-A82A06A79F64}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Extra", "Extra", "{16A2D2FA-6D59-498E-8160-66518531792E}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "System.Reactive.Windows.Forms", "System.Reactive.Windows.Forms\System.Reactive.Windows.Forms.xproj", "{C17D3BD1-222F-4DCC-BBF8-44A04399701B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -32,8 +48,44 @@ Global
 		{7DD3DDA0-0B73-4A7F-ACAF-15111AC2EB93}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7DD3DDA0-0B73-4A7F-ACAF-15111AC2EB93}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7DD3DDA0-0B73-4A7F-ACAF-15111AC2EB93}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5965A929-C3E5-42AD-8328-3641F8967E72}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5965A929-C3E5-42AD-8328-3641F8967E72}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5965A929-C3E5-42AD-8328-3641F8967E72}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5965A929-C3E5-42AD-8328-3641F8967E72}.Release|Any CPU.Build.0 = Release|Any CPU
+		{845E4FBF-A6C0-4870-9D1A-C832E262D956}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{845E4FBF-A6C0-4870-9D1A-C832E262D956}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{845E4FBF-A6C0-4870-9D1A-C832E262D956}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{845E4FBF-A6C0-4870-9D1A-C832E262D956}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FB2DB31D-FCFA-45CE-A3A8-7B7C14ECD77A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FB2DB31D-FCFA-45CE-A3A8-7B7C14ECD77A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FB2DB31D-FCFA-45CE-A3A8-7B7C14ECD77A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FB2DB31D-FCFA-45CE-A3A8-7B7C14ECD77A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C18C6FE5-7408-4F3B-B562-7A563E01701E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C18C6FE5-7408-4F3B-B562-7A563E01701E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C18C6FE5-7408-4F3B-B562-7A563E01701E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C18C6FE5-7408-4F3B-B562-7A563E01701E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A22F3131-6D20-4D67-9A9F-314FE3691EA1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A22F3131-6D20-4D67-9A9F-314FE3691EA1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A22F3131-6D20-4D67-9A9F-314FE3691EA1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A22F3131-6D20-4D67-9A9F-314FE3691EA1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C17D3BD1-222F-4DCC-BBF8-44A04399701B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C17D3BD1-222F-4DCC-BBF8-44A04399701B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C17D3BD1-222F-4DCC-BBF8-44A04399701B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C17D3BD1-222F-4DCC-BBF8-44A04399701B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{FDA62C35-4174-44B0-BEBE-61E80B2515BA} = {0410EFCB-757C-46BA-99AA-A82A06A79F64}
+		{430061B8-8504-483F-A532-CEB69FF04128} = {0410EFCB-757C-46BA-99AA-A82A06A79F64}
+		{A5508FF0-93B9-4241-B666-07B05189C435} = {0410EFCB-757C-46BA-99AA-A82A06A79F64}
+		{7DD3DDA0-0B73-4A7F-ACAF-15111AC2EB93} = {0410EFCB-757C-46BA-99AA-A82A06A79F64}
+		{5965A929-C3E5-42AD-8328-3641F8967E72} = {16A2D2FA-6D59-498E-8160-66518531792E}
+		{845E4FBF-A6C0-4870-9D1A-C832E262D956} = {16A2D2FA-6D59-498E-8160-66518531792E}
+		{FB2DB31D-FCFA-45CE-A3A8-7B7C14ECD77A} = {16A2D2FA-6D59-498E-8160-66518531792E}
+		{C18C6FE5-7408-4F3B-B562-7A563E01701E} = {0410EFCB-757C-46BA-99AA-A82A06A79F64}
+		{A22F3131-6D20-4D67-9A9F-314FE3691EA1} = {16A2D2FA-6D59-498E-8160-66518531792E}
+		{C17D3BD1-222F-4DCC-BBF8-44A04399701B} = {0410EFCB-757C-46BA-99AA-A82A06A79F64}
 	EndGlobalSection
 EndGlobal

--- a/Rx.NET/Source/Rx-New.sln
+++ b/Rx.NET/Source/Rx-New.sln
@@ -1,0 +1,39 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.23107.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "System.Reactive.Core", "System.Reactive.Core\System.Reactive.Core.xproj", "{FDA62C35-4174-44B0-BEBE-61E80B2515BA}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "System.Reactive.Interfaces", "System.Reactive.Interfaces\System.Reactive.Interfaces.xproj", "{430061B8-8504-483F-A532-CEB69FF04128}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "System.Reactive.Linq", "System.Reactive.Linq\System.Reactive.Linq.xproj", "{A5508FF0-93B9-4241-B666-07B05189C435}"
+EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "System.Reactive.PlatformServices", "System.Reactive.PlatformServices\System.Reactive.PlatformServices.xproj", "{7DD3DDA0-0B73-4A7F-ACAF-15111AC2EB93}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{FDA62C35-4174-44B0-BEBE-61E80B2515BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FDA62C35-4174-44B0-BEBE-61E80B2515BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FDA62C35-4174-44B0-BEBE-61E80B2515BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FDA62C35-4174-44B0-BEBE-61E80B2515BA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{430061B8-8504-483F-A532-CEB69FF04128}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{430061B8-8504-483F-A532-CEB69FF04128}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{430061B8-8504-483F-A532-CEB69FF04128}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{430061B8-8504-483F-A532-CEB69FF04128}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5508FF0-93B9-4241-B666-07B05189C435}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5508FF0-93B9-4241-B666-07B05189C435}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A5508FF0-93B9-4241-B666-07B05189C435}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A5508FF0-93B9-4241-B666-07B05189C435}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7DD3DDA0-0B73-4A7F-ACAF-15111AC2EB93}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7DD3DDA0-0B73-4A7F-ACAF-15111AC2EB93}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7DD3DDA0-0B73-4A7F-ACAF-15111AC2EB93}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7DD3DDA0-0B73-4A7F-ACAF-15111AC2EB93}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Rx.NET/Source/System.Reactive.Core/System.Reactive.Core.xproj
+++ b/Rx.NET/Source/System.Reactive.Core/System.Reactive.Core.xproj
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>fda62c35-4174-44b0-bebe-61e80b2515ba</ProjectGuid>
+    <RootNamespace>System.Reactive</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <UserProperties project_1json__JSONSchema="http://json.schemastore.org/project-1.0.0-beta8" />
+    </VisualStudio>
+  </ProjectExtensions>
+</Project>

--- a/Rx.NET/Source/System.Reactive.Core/project.json
+++ b/Rx.NET/Source/System.Reactive.Core/project.json
@@ -1,0 +1,74 @@
+﻿{
+    "version": "3.0.0-*",
+    "title": "Reactive Extensions - Core Library",
+    "description": "Reactive Extensions Core Library containing base classes and scheduler infrastructure.",
+    "authors": [ "Microsoft" ],
+    "copyright": "Copyright (C) Microsoft Corporation",
+    "tags": [ "Rx", "Reactive", "Extensions", "Observable", "LINQ", "Events" ],
+    "iconUrl": "http://go.microsoft.com/fwlink/?LinkId=261274",
+    "projectUrl": "http://go.microsoft.com/fwlink/?LinkId=261273",
+    "licenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+    "requireLicenseAcceptance": true,
+
+    "dependencies": {
+        "System.Reactive.Interfaces": { "target": "project" }
+    },
+
+    "frameworks": {
+        "net40": {
+            "compilationOptions": {
+                "define": [
+                    "NO_TASK_DELAY",
+                    "HAS_APTCA",
+                    "HAS_WINFORMS",
+                    "USE_TIMER_SELF_ROOT",
+                    "NO_WEAKREFOFT"
+                ]
+            }
+        },
+        "net45": {
+            "compilationOptions": {
+                "define": [
+                    "NO_EVENTARGS_CONSTRAINT",
+                    "HAS_EDI",
+                    "HAS_WINRT",
+                    "HAS_PROGRESS",
+                    "PREFER_ASYNC",
+                    "HAS_AWAIT",
+                    "HAS_APTCA",
+                    "HAS_DISPATCHER_PRIORITY",
+                    "HAS_WINFORMS",
+                    "USE_TIMER_SELF_ROOT"
+                ]
+            }
+        },
+        "dotnet5.4": {
+            "compilationOptions": {
+                "define": [
+                    "NO_EVENTARGS_CONSTRAINT",
+                    "HAS_EDI",
+                    "HAS_WINRT",
+                    "HAS_PROGRESS",
+                    "PREFER_ASYNC",
+                    "HAS_AWAIT",
+                    "HAS_APTCA",
+                    "NO_REMOTING",
+                    "NO_SERIALIZABLE",
+                    "NO_THREAD",
+                    "CRIPPLED_REFLECTION",
+                    "PLIB",
+                    "USE_TIMER_SELF_ROOT"
+                ]
+            },
+            "dependencies": {
+                "System.Collections.Concurrent": "4.0.11-beta-23516",
+                "System.ComponentModel": "4.0.1-beta-23516",
+                "System.Linq": "4.0.1-beta-23516",
+                "System.Threading": "4.0.11-beta-23516",
+                "System.Threading.Thread": "4.0.0-beta-23516",
+                "System.Threading.ThreadPool": "4.0.10-beta-23516",
+                "System.Threading.Timer": "4.0.1-beta-23516"
+            }
+        }
+    }
+}

--- a/Rx.NET/Source/System.Reactive.Experimental/System.Reactive.Experimental.xproj
+++ b/Rx.NET/Source/System.Reactive.Experimental/System.Reactive.Experimental.xproj
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>fb2db31d-fcfa-45ce-a3a8-7b7c14ecd77a</ProjectGuid>
+    <RootNamespace>System.Reactive.Experimental</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+    <TypeScriptCompileBlocked>True</TypeScriptCompileBlocked>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <UserProperties project_1json__JSONSchema="http://json.schemastore.org/project-1.0.0-beta8" />
+    </VisualStudio>
+  </ProjectExtensions>
+</Project>

--- a/Rx.NET/Source/System.Reactive.Experimental/project.json
+++ b/Rx.NET/Source/System.Reactive.Experimental/project.json
@@ -1,7 +1,7 @@
 ﻿{
     "version": "3.0.0-*",
-    "title": "Reactive Extensions - Query Library",
-    "description": "Reactive Extensions Query Library used to express complex event processing queries over observable sequences.",
+    "title": "Reactive Extensions - Experimental Library",
+    "description": "Reactive Extensions Experimental Library containing unstable and infrequently used functionality.",
     "authors": [ "Microsoft" ],
     "copyright": "Copyright (C) Microsoft Corporation",
     "tags": [ "Rx", "Reactive", "Extensions", "Observable", "LINQ", "Events" ],
@@ -10,15 +10,10 @@
     "licenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
     "requireLicenseAcceptance": true,
 
-  "exclude": [
-    "*/**/ImmutableList.cs",
-    "Reactive/Observer.Extensions.cs",
-    "Reactive/Internal/Observers.cs",
-    "Reactive/Internal/Producer.cs"
-  ],
-
     "dependencies": {
-        "System.Reactive.Core": { "target": "project" }
+        "System.Reactive.Interfaces": { "target": "project" },
+        "System.Reactive.Core": { "target": "project" },
+        "System.Reactive.Linq": { "target": "project" }
     },
 
     "frameworks": {
@@ -69,8 +64,12 @@
             },
             "dependencies": {
                 "System.Collections.Concurrent": "4.0.11-beta-23516",
-                "System.Reflection.TypeExtensions": "4.1.0-beta-23516",
-                "System.Runtime.InteropServices.WindowsRuntime": "4.0.1-beta-23516"
+                "System.ComponentModel": "4.0.1-beta-23516",
+                "System.Linq": "4.0.1-beta-23516",
+                "System.Threading": "4.0.11-beta-23516",
+                "System.Threading.Thread": "4.0.0-beta-23516",
+                "System.Threading.ThreadPool": "4.0.10-beta-23516",
+                "System.Threading.Timer": "4.0.1-beta-23516"
             }
         }
     }

--- a/Rx.NET/Source/System.Reactive.Interfaces/System.Reactive.Interfaces.xproj
+++ b/Rx.NET/Source/System.Reactive.Interfaces/System.Reactive.Interfaces.xproj
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>430061b8-8504-483f-a532-ceb69ff04128</ProjectGuid>
+    <RootNamespace>System.Reactive</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <UserProperties project_1json__JSONSchema="http://json.schemastore.org/project-1.0.0-beta8" />
+    </VisualStudio>
+  </ProjectExtensions>
+</Project>

--- a/Rx.NET/Source/System.Reactive.Interfaces/project.json
+++ b/Rx.NET/Source/System.Reactive.Interfaces/project.json
@@ -1,0 +1,68 @@
+﻿{
+    "version": "3.0.0-*",
+    "title": "Reactive Extensions - Interfaces Library",
+    "description": "Reactive Extensions Interfaces Library containing essential interfaces.",
+    "authors": [ "Microsoft" ],
+    "copyright": "Copyright (C) Microsoft Corporation",
+    "tags": [ "Rx", "Reactive", "Extensions", "Observable", "LINQ", "Events" ],
+    "iconUrl": "http://go.microsoft.com/fwlink/?LinkId=261274",
+    "projectUrl": "http://go.microsoft.com/fwlink/?LinkId=261273",
+    "licenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+    "requireLicenseAcceptance": true,
+
+    "frameworks": {
+        "net40": {
+            "compilationOptions": {
+                "define": [
+                    "NO_TASK_DELAY",
+                    "HAS_APTCA",
+                    "HAS_WINFORMS",
+                    "USE_TIMER_SELF_ROOT",
+                    "NO_WEAKREFOFT"
+                ]
+            }
+        },
+        "net45": {
+            "compilationOptions": {
+                "define": [
+                    "NO_EVENTARGS_CONSTRAINT",
+                    "HAS_EDI",
+                    "HAS_WINRT",
+                    "HAS_PROGRESS",
+                    "PREFER_ASYNC",
+                    "HAS_AWAIT",
+                    "HAS_APTCA",
+                    "HAS_DISPATCHER_PRIORITY",
+                    "HAS_WINFORMS",
+                    "USE_TIMER_SELF_ROOT"
+                ]
+            }
+        },
+        "dotnet5.2": {
+            "compilationOptions": {
+                "define": [
+                    "NO_EVENTARGS_CONSTRAINT",
+                    "HAS_EDI",
+                    "HAS_WINRT",
+                    "HAS_PROGRESS",
+                    "PREFER_ASYNC",
+                    "HAS_AWAIT",
+                    "HAS_APTCA",
+                    "NO_REMOTING",
+                    "NO_SERIALIZABLE",
+                    "NO_THREAD",
+                    "CRIPPLED_REFLECTION",
+                    "PLIB",
+                    "USE_TIMER_SELF_ROOT"
+                ]
+            },
+            "dependencies": {
+                "System.Diagnostics.Tools": "4.0.1-beta-23516",
+                "System.Linq": "4.0.1-beta-23516",
+                "System.Linq.Expressions": "4.0.11-beta-23516",
+                "System.Resources.ResourceManager": "4.0.1-beta-23516",
+                "System.Threading": "4.0.11-beta-23516"
+            }
+        }
+    }
+}

--- a/Rx.NET/Source/System.Reactive.Linq/System.Reactive.Linq.xproj
+++ b/Rx.NET/Source/System.Reactive.Linq/System.Reactive.Linq.xproj
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>a5508ff0-93b9-4241-b666-07b05189c435</ProjectGuid>
+    <RootNamespace>System.Reactive</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <UserProperties project_1json__JSONSchema="http://json.schemastore.org/project-1.0.0-beta8" />
+    </VisualStudio>
+  </ProjectExtensions>
+</Project>

--- a/Rx.NET/Source/System.Reactive.Linq/project.json
+++ b/Rx.NET/Source/System.Reactive.Linq/project.json
@@ -1,0 +1,72 @@
+﻿{
+    "version": "3.0.0-*",
+    "title": "Reactive Extensions - Query Library",
+    "description": "Reactive Extensions Query Library used to express complex event processing queries over observable sequences.",
+    "authors": [ "Microsoft" ],
+    "copyright": "Copyright (C) Microsoft Corporation",
+    "tags": [ "Rx", "Reactive", "Extensions", "Observable", "LINQ", "Events" ],
+    "iconUrl": "http://go.microsoft.com/fwlink/?LinkId=261274",
+    "projectUrl": "http://go.microsoft.com/fwlink/?LinkId=261273",
+    "licenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+    "requireLicenseAcceptance": true,
+
+    "exclude": [ "*/**/ImmutableList.cs" ],
+
+    "dependencies": {
+        "System.Reactive.Core": { "target": "project" }
+    },
+
+    "frameworks": {
+        "net40": {
+            "compilationOptions": {
+                "define": [
+                    "NO_TASK_DELAY",
+                    "HAS_APTCA",
+                    "HAS_WINFORMS",
+                    "USE_TIMER_SELF_ROOT",
+                    "NO_WEAKREFOFT"
+                ]
+            }
+        },
+        "net45": {
+            "compilationOptions": {
+                "define": [
+                    "NO_EVENTARGS_CONSTRAINT",
+                    "HAS_EDI",
+                    "HAS_WINRT",
+                    "HAS_PROGRESS",
+                    "PREFER_ASYNC",
+                    "HAS_AWAIT",
+                    "HAS_APTCA",
+                    "HAS_DISPATCHER_PRIORITY",
+                    "HAS_WINFORMS",
+                    "USE_TIMER_SELF_ROOT"
+                ]
+            }
+        },
+        "dotnet5.4": {
+            "compilationOptions": {
+                "define": [
+                    "NO_EVENTARGS_CONSTRAINT",
+                    "HAS_EDI",
+                    "HAS_WINRT",
+                    "HAS_PROGRESS",
+                    "PREFER_ASYNC",
+                    "HAS_AWAIT",
+                    "HAS_APTCA",
+                    "NO_REMOTING",
+                    "NO_SERIALIZABLE",
+                    "NO_THREAD",
+                    "CRIPPLED_REFLECTION",
+                    "PLIB",
+                    "USE_TIMER_SELF_ROOT"
+                ]
+            },
+            "dependencies": {
+                "System.Collections.Concurrent": "4.0.11-beta-23516",
+                "System.Reflection.TypeExtensions": "4.1.0-beta-23516",
+                "System.Runtime.InteropServices.WindowsRuntime": "4.0.1-beta-23516"
+            }
+        }
+    }
+}

--- a/Rx.NET/Source/System.Reactive.Observable.Aliases/System.Reactive.Observable.Aliases.xproj
+++ b/Rx.NET/Source/System.Reactive.Observable.Aliases/System.Reactive.Observable.Aliases.xproj
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>5965a929-c3e5-42ad-8328-3641f8967e72</ProjectGuid>
+    <RootNamespace>System.Reactive.Observable.Aliases</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+    <TypeScriptCompileBlocked>True</TypeScriptCompileBlocked>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <UserProperties project_1json__JSONSchema="http://json.schemastore.org/project-1.0.0-beta8" />
+    </VisualStudio>
+  </ProjectExtensions>
+</Project>

--- a/Rx.NET/Source/System.Reactive.Observable.Aliases/project.json
+++ b/Rx.NET/Source/System.Reactive.Observable.Aliases/project.json
@@ -1,0 +1,74 @@
+﻿{
+  "version": "3.0.0-*",
+  "title": "Reactive Extensions - Core Library",
+  "description": "Reactive Extensions Core Library containing base classes and scheduler infrastructure.",
+  "authors": [ "Microsoft" ],
+  "copyright": "Copyright (C) Microsoft Corporation",
+  "tags": [ "Rx", "Reactive", "Extensions", "Observable", "LINQ", "Events" ],
+  "iconUrl": "http://go.microsoft.com/fwlink/?LinkId=261274",
+  "projectUrl": "http://go.microsoft.com/fwlink/?LinkId=261273",
+  "licenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+  "requireLicenseAcceptance": true,
+
+  "dependencies": {
+    "System.Reactive.Providers": { "target": "project" }
+  },
+
+  "frameworks": {
+    "net40": {
+      "compilationOptions": {
+        "define": [
+          "NO_TASK_DELAY",
+          "HAS_APTCA",
+          "HAS_WINFORMS",
+          "USE_TIMER_SELF_ROOT",
+          "NO_WEAKREFOFT"
+        ]
+      }
+    },
+    "net45": {
+      "compilationOptions": {
+        "define": [
+          "NO_EVENTARGS_CONSTRAINT",
+          "HAS_EDI",
+          "HAS_WINRT",
+          "HAS_PROGRESS",
+          "PREFER_ASYNC",
+          "HAS_AWAIT",
+          "HAS_APTCA",
+          "HAS_DISPATCHER_PRIORITY",
+          "HAS_WINFORMS",
+          "USE_TIMER_SELF_ROOT"
+        ]
+      }
+    },
+    "dotnet5.4": {
+      "compilationOptions": {
+        "define": [
+          "NO_EVENTARGS_CONSTRAINT",
+          "HAS_EDI",
+          "HAS_WINRT",
+          "HAS_PROGRESS",
+          "PREFER_ASYNC",
+          "HAS_AWAIT",
+          "HAS_APTCA",
+          "NO_REMOTING",
+          "NO_SERIALIZABLE",
+          "NO_THREAD",
+          "CRIPPLED_REFLECTION",
+          "PLIB",
+          "USE_TIMER_SELF_ROOT"
+        ]
+      },
+      "dependencies": {
+        "System.Collections.Concurrent": "4.0.11-beta-23516",
+        "System.ComponentModel": "4.0.1-beta-23516",
+        "System.Linq": "4.0.1-beta-23516",
+        "System.Threading": "4.0.11-beta-23516",
+        "System.Threading.Thread": "4.0.0-beta-23516",
+        "System.Threading.ThreadPool": "4.0.10-beta-23516",
+        "System.Threading.Timer": "4.0.1-beta-23516"
+      }
+    }
+  }
+}

--- a/Rx.NET/Source/System.Reactive.PlatformServices/System.Reactive.PlatformServices.xproj
+++ b/Rx.NET/Source/System.Reactive.PlatformServices/System.Reactive.PlatformServices.xproj
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>7dd3dda0-0b73-4a7f-acaf-15111ac2eb93</ProjectGuid>
+    <RootNamespace>System.Reactive.PlatformServices</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/Rx.NET/Source/System.Reactive.PlatformServices/project.json
+++ b/Rx.NET/Source/System.Reactive.PlatformServices/project.json
@@ -1,0 +1,71 @@
+﻿{
+    "version": "3.0.0-*",
+    "title": "Reactive Extensions - Platform Services Library",
+    "description": "Reactive Extensions Platform Services Library used to access platform-specific functionality and enlightenment services.",
+    "authors": [ "Microsoft" ],
+    "copyright": "Copyright (C) Microsoft Corporation",
+    "tags": [ "Rx", "Reactive", "Extensions", "Observable", "LINQ", "Events" ],
+    "iconUrl": "http://go.microsoft.com/fwlink/?LinkId=261274",
+    "projectUrl": "http://go.microsoft.com/fwlink/?LinkId=261273",
+    "licenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+    "requireLicenseAcceptance": true,
+
+    "exclude": [ "Strings_PlatformServices.Designer.cs" ],
+
+    "dependencies": {
+        "System.Reactive.Linq": { "target": "project" }
+    },
+
+    "frameworks": {
+        "net40": {
+            "compilationOptions": {
+                "define": [
+                    "NO_TASK_DELAY",
+                    "HAS_APTCA",
+                    "HAS_WINFORMS",
+                    "USE_TIMER_SELF_ROOT",
+                    "NO_WEAKREFOFT"
+                ]
+            }
+        },
+        "net45": {
+            "compilationOptions": {
+                "define": [
+                    "NO_EVENTARGS_CONSTRAINT",
+                    "HAS_EDI",
+                    "HAS_WINRT",
+                    "HAS_PROGRESS",
+                    "PREFER_ASYNC",
+                    "HAS_AWAIT",
+                    "HAS_APTCA",
+                    "HAS_DISPATCHER_PRIORITY",
+                    "HAS_WINFORMS",
+                    "USE_TIMER_SELF_ROOT"
+                ]
+            }
+        },
+        "dotnet5.4": {
+            "compilationOptions": {
+                "define": [
+                    "NO_EVENTARGS_CONSTRAINT",
+                    "HAS_EDI",
+                    "HAS_WINRT",
+                    "HAS_PROGRESS",
+                    "PREFER_ASYNC",
+                    "HAS_AWAIT",
+                    "HAS_APTCA",
+                    "NO_REMOTING",
+                    "NO_SERIALIZABLE",
+                    "NO_THREAD",
+                    "CRIPPLED_REFLECTION",
+                    "PLIB",
+                    "USE_TIMER_SELF_ROOT"
+                ]
+            },
+            "dependencies": {
+                "System.Diagnostics.Tools": "4.0.1-beta-23516",
+                "System.Diagnostics.Debug": "4.0.11-beta-23516"
+            }
+        }
+    }
+}

--- a/Rx.NET/Source/System.Reactive.Providers/System.Reactive.Providers.xproj
+++ b/Rx.NET/Source/System.Reactive.Providers/System.Reactive.Providers.xproj
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>845e4fbf-a6c0-4870-9d1a-c832e262d956</ProjectGuid>
+    <RootNamespace>System.Reactive.Observable.Aliases</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+    <TypeScriptCompileBlocked>True</TypeScriptCompileBlocked>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <UserProperties project_1json__JSONSchema="http://json.schemastore.org/project-1.0.0-beta8" />
+    </VisualStudio>
+  </ProjectExtensions>
+</Project>

--- a/Rx.NET/Source/System.Reactive.Providers/project.json
+++ b/Rx.NET/Source/System.Reactive.Providers/project.json
@@ -1,0 +1,78 @@
+﻿{
+    "version": "3.0.0-*",
+    "title": "Reactive Extensions - Core Library",
+    "description": "Reactive Extensions Core Library containing base classes and scheduler infrastructure.",
+    "authors": [ "Microsoft" ],
+    "copyright": "Copyright (C) Microsoft Corporation",
+    "tags": [ "Rx", "Reactive", "Extensions", "Observable", "LINQ", "Events" ],
+    "iconUrl": "http://go.microsoft.com/fwlink/?LinkId=261274",
+    "projectUrl": "http://go.microsoft.com/fwlink/?LinkId=261273",
+    "licenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+    "requireLicenseAcceptance": true,
+
+    "dependencies": {
+        "System.Reactive.Linq": { "target": "project" }
+    },
+
+    "frameworks": {
+        "net40": {
+            "compilationOptions": {
+                "define": [
+                    "NO_TASK_DELAY",
+                    "HAS_APTCA",
+                    "HAS_WINFORMS",
+                    "USE_TIMER_SELF_ROOT",
+                    "NO_WEAKREFOFT"
+                ]
+            }
+        },
+        "net45": {
+          "compilationOptions": {
+            "define": [
+              "NO_EVENTARGS_CONSTRAINT",
+              "HAS_EDI",
+              "HAS_WINRT",
+              "HAS_PROGRESS",
+              "PREFER_ASYNC",
+              "HAS_AWAIT",
+              "HAS_APTCA",
+              "HAS_DISPATCHER_PRIORITY",
+              "HAS_WINFORMS",
+              "USE_TIMER_SELF_ROOT"
+            ]
+          },
+          "dependencies": {
+            "System.Reflection": "4.1.0-beta-23516"
+          }
+        },
+        "dotnet5.4": {
+            "compilationOptions": {
+              "define": [
+                "NO_EVENTARGS_CONSTRAINT",
+                "HAS_EDI",
+                "HAS_WINRT",
+                "HAS_PROGRESS",
+                "PREFER_ASYNC",
+                "HAS_AWAIT",
+                "HAS_APTCA",
+                "NO_REMOTING",
+                "NO_SERIALIZABLE",
+                "NO_THREAD",
+                "CRIPPLED_REFLECTION",
+                "PLIB",
+                "USE_TIMER_SELF_ROOT"
+              ]
+            },
+          "dependencies": {
+            "System.Collections.Concurrent": "4.0.11-beta-23516",
+            "System.ComponentModel": "4.0.1-beta-23516",
+            "System.Linq": "4.0.1-beta-23516",
+            "System.Linq.Queryable": "4.0.1-beta-23516",
+            "System.Threading": "4.0.11-beta-23516",
+            "System.Threading.Thread": "4.0.0-beta-23516",
+            "System.Threading.ThreadPool": "4.0.10-beta-23516",
+            "System.Threading.Timer": "4.0.1-beta-23516"
+          }
+        }
+    }
+}

--- a/Rx.NET/Source/System.Reactive.Runtime.Remoting/System.Reactive.Runtime.Remoting.xproj
+++ b/Rx.NET/Source/System.Reactive.Runtime.Remoting/System.Reactive.Runtime.Remoting.xproj
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>a22f3131-6d20-4d67-9a9f-314fe3691ea1</ProjectGuid>
+    <RootNamespace>System.Reactive.Observable.Aliases</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+    <TypeScriptCompileBlocked>True</TypeScriptCompileBlocked>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <UserProperties project_1json__JSONSchema="http://json.schemastore.org/project-1.0.0-beta8" />
+    </VisualStudio>
+  </ProjectExtensions>
+</Project>

--- a/Rx.NET/Source/System.Reactive.Runtime.Remoting/project.json
+++ b/Rx.NET/Source/System.Reactive.Runtime.Remoting/project.json
@@ -1,0 +1,78 @@
+﻿{
+    "version": "3.0.0-*",
+    "title": "System.Reactive.Runtime.Remoting",
+    "description": "Reactive Extensions Remoting Library used to expose observable sequences through .NET Remoting.",
+    "authors": [ "Microsoft" ],
+    "copyright": "Copyright (C) Microsoft Corporation",
+    "tags": [ "Rx", "Reactive", "Extensions", "Observable", "LINQ", "Events" ],
+    "iconUrl": "http://go.microsoft.com/fwlink/?LinkId=261274",
+    "projectUrl": "http://go.microsoft.com/fwlink/?LinkId=261273",
+    "licenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+    "requireLicenseAcceptance": true,
+
+    "dependencies": {
+        "System.Reactive.Core": { "target": "project" }
+    },
+
+    "frameworks": {
+        "net40": {
+            "compilationOptions": {
+                "define": [
+                    "NO_TASK_DELAY",
+                    "HAS_APTCA",
+                    "HAS_WINFORMS",
+                    "USE_TIMER_SELF_ROOT",
+                    "NO_WEAKREFOFT"
+                ]
+            }
+        },
+        "net45": {
+          "compilationOptions": {
+            "define": [
+              "NO_EVENTARGS_CONSTRAINT",
+              "HAS_EDI",
+              "HAS_WINRT",
+              "HAS_PROGRESS",
+              "PREFER_ASYNC",
+              "HAS_AWAIT",
+              "HAS_APTCA",
+              "HAS_DISPATCHER_PRIORITY",
+              "HAS_WINFORMS",
+              "USE_TIMER_SELF_ROOT"
+            ]
+          },
+          "dependencies": {
+            "System.Reflection": "4.1.0-beta-23516"
+          }
+        },
+        "dotnet5.4": {
+            "compilationOptions": {
+              "define": [
+                "NO_EVENTARGS_CONSTRAINT",
+                "HAS_EDI",
+                "HAS_WINRT",
+                "HAS_PROGRESS",
+                "PREFER_ASYNC",
+                "HAS_AWAIT",
+                "HAS_APTCA",
+                "NO_REMOTING",
+                "NO_SERIALIZABLE",
+                "NO_THREAD",
+                "CRIPPLED_REFLECTION",
+                "PLIB",
+                "USE_TIMER_SELF_ROOT"
+              ]
+            },
+          "dependencies": {
+            "System.Collections.Concurrent": "4.0.11-beta-23516",
+            "System.ComponentModel": "4.0.1-beta-23516",
+            "System.Linq": "4.0.1-beta-23516",
+            "System.Linq.Queryable": "4.0.1-beta-23516",
+            "System.Threading": "4.0.11-beta-23516",
+            "System.Threading.Thread": "4.0.0-beta-23516",
+            "System.Threading.ThreadPool": "4.0.10-beta-23516",
+            "System.Threading.Timer": "4.0.1-beta-23516"
+          }
+        }
+    }
+}

--- a/Rx.NET/Source/System.Reactive.Windows.Forms/System.Reactive.Windows.Forms.xproj
+++ b/Rx.NET/Source/System.Reactive.Windows.Forms/System.Reactive.Windows.Forms.xproj
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>c17d3bd1-222f-4dcc-bbf8-44a04399701b</ProjectGuid>
+    <RootNamespace>System.Reactive</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+    <TypeScriptCompileBlocked>True</TypeScriptCompileBlocked>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <UserProperties project_1json__JSONSchema="http://json.schemastore.org/project-1.0.0-beta8" />
+    </VisualStudio>
+  </ProjectExtensions>
+</Project>

--- a/Rx.NET/Source/System.Reactive.Windows.Forms/project.json
+++ b/Rx.NET/Source/System.Reactive.Windows.Forms/project.json
@@ -1,0 +1,56 @@
+﻿{
+  "version": "3.0.0-*",
+  "title": "Reactive Extensions - Windows Forms Helpers",
+  "description": "Windows Forms extensions library for Rx. Contains scheduler functionality for the Windows Forms UI loop.",
+  "authors": [ "Microsoft" ],
+  "copyright": "Copyright (C) Microsoft Corporation",
+  "tags": [ "Rx", "Reactive", "Extensions", "Observable", "LINQ", "Events" ],
+  "iconUrl": "http://go.microsoft.com/fwlink/?LinkId=261274",
+  "projectUrl": "http://go.microsoft.com/fwlink/?LinkId=261273",
+  "licenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+  "requireLicenseAcceptance": true,
+
+  "dependencies": {
+    "System.Reactive.Interfaces": { "target": "project" },
+    "System.Reactive.Core": { "target": "project" }
+  },
+
+  "frameworks": {
+    "net40": {
+      "compilationOptions": {
+        "define": [
+          "NO_TASK_DELAY",
+          "HAS_APTCA",
+          "HAS_WINFORMS",
+          "USE_TIMER_SELF_ROOT",
+          "NO_WEAKREFOFT"
+        ]
+      },
+      "frameworkAssemblies": {
+        "System.Windows.Forms": "4.0.0.0",
+        "WindowsBase": "4.0.0.0"
+      }
+    },
+    "net45": {
+      "compilationOptions": {
+        "define": [
+          "NO_EVENTARGS_CONSTRAINT",
+          "HAS_EDI",
+          "HAS_WINRT",
+          "HAS_PROGRESS",
+          "PREFER_ASYNC",
+          "HAS_AWAIT",
+          "HAS_APTCA",
+          "HAS_DISPATCHER_PRIORITY",
+          "HAS_WINFORMS",
+          "USE_TIMER_SELF_ROOT"
+        ]
+      },
+      "frameworkAssemblies": {
+        "System.Windows": "4.0.0.0",
+        "System.Windows.Forms": "4.0.0.0",
+        "WindowsBase": "4.0.0.0"
+      }
+    }
+  }
+}

--- a/Rx.NET/Source/System.Reactive.Windows.Threading/System.Reactive.Windows.Threading.xproj
+++ b/Rx.NET/Source/System.Reactive.Windows.Threading/System.Reactive.Windows.Threading.xproj
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>c18c6fe5-7408-4f3b-b562-7a563e01701e</ProjectGuid>
+    <RootNamespace>System.Reactive</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">..\..\..\artifacts\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">..\..\..\artifacts\bin\$(MSBuildProjectName)\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+    <TypeScriptCompileBlocked>True</TypeScriptCompileBlocked>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <ProduceOutputsOnBuild>True</ProduceOutputsOnBuild>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DNX\Microsoft.DNX.targets" Condition="'$(VSToolsPath)' != ''" />
+  <ProjectExtensions>
+    <VisualStudio>
+      <UserProperties project_1json__JSONSchema="http://json.schemastore.org/project-1.0.0-beta8" />
+    </VisualStudio>
+  </ProjectExtensions>
+</Project>

--- a/Rx.NET/Source/System.Reactive.Windows.Threading/project.json
+++ b/Rx.NET/Source/System.Reactive.Windows.Threading/project.json
@@ -1,0 +1,54 @@
+﻿{
+  "version": "3.0.0-*",
+  "title": "Reactive Extensions - WPF Helpers",
+  "description": "Windows Presentation Foundation extensions library for Rx. Contains scheduler functionality for the WPF Dispatcher.",
+  "authors": [ "Microsoft" ],
+  "copyright": "Copyright (C) Microsoft Corporation",
+  "tags": [ "Rx", "Reactive", "Extensions", "Observable", "LINQ", "Events" ],
+  "iconUrl": "http://go.microsoft.com/fwlink/?LinkId=261274",
+  "projectUrl": "http://go.microsoft.com/fwlink/?LinkId=261273",
+  "licenseUrl": "http://go.microsoft.com/fwlink/?LinkID=261272",
+  "requireLicenseAcceptance": true,
+
+  "dependencies": {
+    "System.Reactive.Interfaces": { "target": "project" },
+    "System.Reactive.Core": { "target": "project" }
+  },
+
+  "frameworks": {
+    "net40": {
+      "compilationOptions": {
+        "define": [
+          "NO_TASK_DELAY",
+          "HAS_APTCA",
+          "HAS_WINFORMS",
+          "USE_TIMER_SELF_ROOT",
+          "NO_WEAKREFOFT"
+        ]
+      },
+      "frameworkAssemblies": {
+        "WindowsBase": "4.0.0.0"
+      }
+    },
+    "net45": {
+      "compilationOptions": {
+        "define": [
+          "NO_EVENTARGS_CONSTRAINT",
+          "HAS_EDI",
+          "HAS_WINRT",
+          "HAS_PROGRESS",
+          "PREFER_ASYNC",
+          "HAS_AWAIT",
+          "HAS_APTCA",
+          "HAS_DISPATCHER_PRIORITY",
+          "HAS_WINFORMS",
+          "USE_TIMER_SELF_ROOT"
+        ]
+      },
+      "frameworkAssemblies": {
+        "System.Windows": "4.0.0.0",
+        "WindowsBase": "4.0.0.0"
+      }
+    }
+  }
+}

--- a/Rx.NET/Source/build-new.ps1
+++ b/Rx.NET/Source/build-new.ps1
@@ -1,0 +1,13 @@
+$msbuild = Get-ItemProperty "hklm:\SOFTWARE\Microsoft\MSBuild\ToolsVersions\14.0"
+# TODO: if not found, bail out
+
+$msbuildExe = Join-Path $msbuild.MSBuildToolsPath "msbuild.exe"
+$build = "1.0.0-rc1-update1"
+
+dnvm use $build -r clr -arch x64 -p
+
+$runtimeDir = Join-Path $env:USERPROFILE "\.dnx\runtimes\dnx-clr-win-x64.$build"
+
+dnu restore . --quiet
+
+. $msbuildExe .\Rx-New.sln /m /p:Configuration=Release /p:RuntimeToolingDirectory=$runtimeDir /v:minimal


### PR DESCRIPTION
I'm opening this up early to see if anyone has some feedback... :eyes:

Currently I have the 4 main projects building for `net40`, `net45` and `dotnet5.4` (`netstandard1.3`), without *any* code changes :smile:
This should cover a minimum of `net40`, `net45`, `net46`, `uap10`, `netcore50` and `dnxcore50`. I *think* this includes the Xamarin products as well :sparkles:

I tried to aim for `dotnet5.2` (`netstandard1.1`), which would include minimum `win8` and `wpa8` as well, but could only get **Interfaces** to compile. Will give it another go soon. :watch:
I currently don't have the tooling for sl5, wp7 and wp8, so I punted on those for now :dancers:

All the preprocessor directives are directly from [Common.targets](https://github.com/Reactive-Extensions/Rx.NET/blob/2252cb4edbb25aca12005b9a912311edd2f095f3/Rx.NET/Source/Common.targets), so hopefully they should be good. Anyway, they're a horrible mess and should :fire: ASAP, once the older targets are deprecated.

There are still a few features that are not supported for project.json yet, like .tt-files etc., so this'll probably have to stay side-by-side for a while :disappointed: 

For reference, see the [standard platform document](https://github.com/dotnet/corefx/blob/master/Documentation/project-docs/standard-platform.md).

Should close #148