### PR TITLE
In EnumerableEx.ForEach, index increment should be checked.

### DIFF
--- a/Ix.NET/Source/System.Interactive/EnumerableEx.Single.cs
+++ b/Ix.NET/Source/System.Interactive/EnumerableEx.Single.cs
@@ -61,7 +61,7 @@ namespace System.Linq
 
             var i = 0;
             foreach (var item in source)
-                onNext(item, i++);
+                onNext(item, checked(i++));
         }
 
         /// <summary>


### PR DESCRIPTION
Index increment is checked in other LINQ methods.