### PR TITLE
Fix the logic of the Sample operator

### DIFF
--- a/Rx.NET/Source/Microsoft.Reactive.Testing/TestScheduler.cs
+++ b/Rx.NET/Source/Microsoft.Reactive.Testing/TestScheduler.cs
@@ -159,5 +159,16 @@ namespace Microsoft.Reactive.Testing
         {
             return new MockObserver<T>(this);
         }
+        
+        /// <summary>
+        /// Advances the scheduler's clock by the specified relative time, running all work scheduled for that timespan.
+        /// </summary>
+        /// <param name="time">Relative time to advance the scheduler's clock by.</param>
+        /// <exception cref="ArgumentOutOfRangeException"><paramref name="time"/> is negative.</exception>
+        /// <exception cref="InvalidOperationException">The scheduler is already running. VirtualTimeScheduler doesn't support running nested work dispatch loops. To simulate time slippage while running work on the scheduler, use <see cref="Sleep"/>.</exception>
+        public void AdvanceBy(TimeSpan time)
+        {
+            base.AdvanceBy(time.Ticks);
+        }
     }
 }

--- a/Rx.NET/Source/System.Reactive.Linq/Reactive/Internal/WeakObservable.cs
+++ b/Rx.NET/Source/System.Reactive.Linq/Reactive/Internal/WeakObservable.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System.Reactive.Disposables;
+
+namespace System.Reactive
+{
+
+    /// <summary>
+    /// Weak reference Observable
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal class WeakObservable<T> : IObservable<T>
+    {
+        private readonly IObservable<T> _source;
+
+        #region Ctor
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WeakObservable{T}"/> class.
+        /// </summary>
+        /// <param name="source">The source.</param>
+        /// <exception cref="System.ArgumentNullException">source</exception>
+        public WeakObservable(IObservable<T> source)
+        {
+            #region Validation
+
+            if (source == null)
+                throw new ArgumentNullException(nameof(source));
+
+            #endregion Validation
+
+            _source = source;
+        }
+
+        #endregion Ctor
+
+        #region Subscribe
+
+        /// <summary>
+        /// Subscribes the specified observer.
+        /// </summary>
+        /// <param name="observer">The observer.</param>
+        /// <returns></returns>
+        public IDisposable Subscribe(IObserver<T> observer)
+        {
+            IObservable<T> source = _source;
+            if (source == null)
+                return Disposable.Empty;
+            var weakObserver = new WeakObserver<T>(observer);
+            IDisposable disp = source.Subscribe(weakObserver);
+            return disp;
+        }
+
+        #endregion Subscribe
+    }
+}

--- a/Rx.NET/Source/System.Reactive.Linq/Reactive/Internal/WeakObserver.cs
+++ b/Rx.NET/Source/System.Reactive.Linq/Reactive/Internal/WeakObserver.cs
@@ -1,0 +1,111 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System.Reactive.PlatformServices;
+
+namespace System.Reactive
+{
+    /// <summary>
+    /// Weak reference Observer
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    internal class WeakObserver<T> : IObserver<T>
+    {
+        private readonly WeakReference<IObserver<T>> _target;
+
+        #region Ctor
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="WeakObserver{T}"/> class.
+        /// </summary>
+        /// <param name="target">The target.</param>
+        /// <exception cref="System.ArgumentNullException">target</exception>
+        public WeakObserver(IObserver<T> target)
+        {
+            #region Validation
+
+            if (target == null)
+                throw new ArgumentNullException(nameof(target));
+
+            #endregion Validation
+
+            _target = new WeakReference<IObserver<T>>(target);
+        }
+
+        #endregion Ctor
+
+        #region Target
+
+        /// <summary>
+        /// Gets the target.
+        /// </summary>
+        /// <value>
+        /// The target.
+        /// </value>
+        private IObserver<T> Target
+        {
+            get
+            {
+                IObserver<T> target;
+                if (_target.TryGetTarget(out target))
+                    return target;
+                return null;
+            }
+        }
+
+        #endregion Target
+
+        #region IObserver<T> Members
+
+        #region OnCompleted
+
+        /// <summary>
+        /// Notifies the observer that the provider has finished sending push-based notifications.
+        /// </summary>
+        public void OnCompleted()
+        {
+            IObserver<T> target = Target;
+            if (target == null)
+                return;
+
+            target.OnCompleted();
+        }
+
+        #endregion OnCompleted
+
+        #region OnError
+
+        /// <summary>
+        /// Notifies the observer that the provider has experienced an error condition.
+        /// </summary>
+        /// <param name="error">An object that provides additional information about the error.</param>
+        public void OnError(Exception error)
+        {
+            IObserver<T> target = Target;
+            if (target == null)
+                return;
+
+            target.OnError(error);
+        }
+
+        #endregion OnError
+
+        #region OnNext
+
+        /// <summary>
+        /// Provides the observer with new data.
+        /// </summary>
+        /// <param name="value">The current notification information.</param>
+        public void OnNext(T value)
+        {
+            IObserver<T> target = Target;
+            if (target == null)
+                return;
+
+            target.OnNext(value);
+        }
+
+        #endregion OnNext
+
+        #endregion IObserver<T> Members
+    }
+}

--- a/Rx.NET/Source/System.Reactive.Linq/Reactive/Linq/Observable/Zip.cs
+++ b/Rx.NET/Source/System.Reactive.Linq/Reactive/Linq/Observable/Zip.cs
@@ -157,6 +157,11 @@ namespace System.Reactive.Linq.ObservableImpl
                         }
                         else
                         {
+                            if (Queue.Count == 0) // no chance for further match
+                            {
+                                _parent._observer.OnCompleted();
+                                _parent.Dispose();
+                            }
                             _self.Dispose();
                         }
                     }

--- a/Rx.NET/Source/System.Reactive.Linq/Reactive/WeakObservable.Extensions.cs
+++ b/Rx.NET/Source/System.Reactive.Linq/Reactive/WeakObservable.Extensions.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System.ComponentModel;
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Threading;
+
+namespace System.Reactive.Linq
+{
+    /// <summary>
+    /// Provides a set of static methods for subscribing delegates to observables.
+    /// </summary>
+    public static class WeakObservableExtensions
+    {
+        #region ToWeakObservable
+
+        /// <summary>
+        /// To weak observable.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="source">The source.</param>
+        /// <returns></returns>
+        public static IObservable<T> ToWeakObservable<T>(this IObservable<T> source)
+        {
+            var result = new WeakObservable<T>(source);
+            return result;
+        }
+
+        #endregion ToWeakObservable
+    }
+}

--- a/Rx.NET/Source/System.Reactive.Linq/System.Reactive.Linq.csproj
+++ b/Rx.NET/Source/System.Reactive.Linq/System.Reactive.Linq.csproj
@@ -39,6 +39,8 @@
     <Compile Include="Reactive\Internal\HashSet.cs" />
     <Compile Include="Reactive\Internal\Lookup.cs" />
     <Compile Include="Reactive\Internal\SortedDictionary.cs" />
+    <Compile Include="Reactive\Internal\WeakObservable.cs" />
+    <Compile Include="Reactive\Internal\WeakObserver.cs" />
     <Compile Include="Reactive\Linq\LocalQueryMethodImplementationTypeAttribute.cs" />
     <Compile Include="Reactive\Linq\Observable\Case.cs" />
     <Compile Include="Reactive\Linq\Observable\Collect.cs" />
@@ -209,6 +211,7 @@
     <Compile Include="Reactive\Threading\Tasks\TaskObservableExtensions.cs" />
     <Compile Include="Reactive\TimeInterval.cs" />
     <Compile Include="Reactive\Timestamped.cs" />
+    <Compile Include="Reactive\WeakObservable.Extensions.cs" />
     <Compile Include="Strings_Linq.Generated.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Rx.NET/Source/Tests.System.Reactive/Tests.System.Reactive.csproj
+++ b/Rx.NET/Source/Tests.System.Reactive/Tests.System.Reactive.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Tests\Linq\Subjects\BehaviorSubjectTest.cs" />
     <Compile Include="Tests\Linq\Subjects\ReplaySubjectTest.cs" />
     <Compile Include="Tests\Linq\Subjects\SubjectTest.cs" />
+    <Compile Include="Tests\Linq\WeakObservableTest.cs" />
     <Compile Include="Tests\MySubject.cs" />
     <Compile Include="Tests\RogueEnumerable.cs" />
     <Compile Include="Tests\SystemClockTest.cs" />

--- a/Rx.NET/Source/Tests.System.Reactive/Tests/Linq/ObservableMultipleTest.cs
+++ b/Rx.NET/Source/Tests.System.Reactive/Tests/Linq/ObservableMultipleTest.cs
@@ -12156,11 +12156,10 @@ namespace ReactiveTests.Tests
                 e.Zip(n, (x, y) => x + y)
             );
 
-            res.Messages.AssertEqual(
-            );
+            res.Messages.AssertEqual(OnCompleted<int>(210));
 
             n.Subscriptions.AssertEqual(
-                Subscribe(200, 1000)
+                Subscribe(200, 210)
             );
 
             e.Subscriptions.AssertEqual(
@@ -12217,12 +12216,12 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnCompleted<int>(220)
+                OnCompleted<int>(210)
             );
 
-            var i = 0;
+            //var i = 0;
             foreach (var e in new[] { e0, e1 })
-                e.Subscriptions.AssertEqual(Subscribe(200, 200 + (++i * 10)));
+                e.Subscriptions.AssertEqual(Subscribe(200, 210));// + (++i * 10)));
         }
 
         [TestMethod]
@@ -12651,7 +12650,7 @@ namespace ReactiveTests.Tests
             );
 
             res.Messages.AssertEqual(
-                OnCompleted<int>(215)
+                OnCompleted<int>(210)
             );
 
             e.Subscriptions.AssertEqual(
@@ -12659,7 +12658,7 @@ namespace ReactiveTests.Tests
             );
 
             o.Subscriptions.AssertEqual(
-                Subscribe(200, 215)
+                Subscribe(200, 210)
             );
         }
 
@@ -12789,7 +12788,7 @@ namespace ReactiveTests.Tests
 
             res.Messages.AssertEqual(
                 OnNext(220, 2 + 3),
-                OnCompleted<int>(240)
+                OnCompleted<int>(230)
             );
 
             o1.Subscriptions.AssertEqual(
@@ -12797,7 +12796,7 @@ namespace ReactiveTests.Tests
             );
 
             o2.Subscriptions.AssertEqual(
-                Subscribe(200, 240)
+                Subscribe(200, 230)
             );
         }
 
@@ -13083,7 +13082,7 @@ namespace ReactiveTests.Tests
 
             res.Messages.AssertEqual(
                 OnNext(215, 6),
-                OnCompleted<int>(225)
+                OnCompleted<int>(220)
             );
 
             o.Subscriptions.AssertEqual(
@@ -13091,7 +13090,7 @@ namespace ReactiveTests.Tests
             );
 
             e.Subscriptions.AssertEqual(
-                Subscribe(200, 225)
+                Subscribe(200, 220)
             );
         }
 
@@ -15804,6 +15803,26 @@ namespace ReactiveTests.Tests
         }
 
         #endregion
+
+
+        [TestMethod]
+        public void Zip_Commpletion_Test()
+        {
+            var scheduler = new TestScheduler();
+
+            var e0 = scheduler.CreateHotObservable(new[] { OnNext(150, "A"), OnCompleted<string>(300) });
+            var e1 = scheduler.CreateHotObservable(new[] { OnNext(200, 1), OnNext(500, 2), OnNext(600, 3) }); //, OnCompleted<int>(900) });
+
+            var res = scheduler.Start(() =>
+                Observable.Zip(e0, e1, (_0, _1) => _0 + _1)
+                , created: 0, subscribed: 0, disposed: 1000);
+
+
+            res.Messages.AssertEqual(// no chance to further matching
+                OnNext(200, "A1"), OnCompleted<string>(300)
+            );
+
+        }
 
         #endregion
     }

--- a/Rx.NET/Source/Tests.System.Reactive/Tests/Linq/ObservableTimeTest.cs
+++ b/Rx.NET/Source/Tests.System.Reactive/Tests/Linq/ObservableTimeTest.cs
@@ -2800,8 +2800,8 @@ namespace ReactiveTests.Tests
                 OnNext(250, 3),
                 OnNext(300, 5), /* CHECK: boundary of sampling */
                 OnNext(350, 6),
-                OnNext(400, 7), /* Sample in last bucket */
-                OnCompleted<int>(400)
+                OnNext(390, 7), /* Sample in last bucket */
+                OnCompleted<int>(390)
             );
 
             xs.Subscriptions.AssertEqual(
@@ -2833,8 +2833,8 @@ namespace ReactiveTests.Tests
                 OnNext(250, 3),
                 OnNext(300, 5), /* CHECK: boundary of sampling */
                 OnNext(350, 6),
-                OnNext(400, 7), /* Sample in last bucket */
-                OnCompleted<int>(400)
+                OnNext(390, 7), /* Sample in last bucket */
+                OnCompleted<int>(390)
             );
 
             xs.Subscriptions.AssertEqual(
@@ -2842,7 +2842,7 @@ namespace ReactiveTests.Tests
             );
 
             scheduler.Timers.AssertEqual(
-                new TimerRun(200, 400) { 250, 300, 350, 400 }
+                new TimerRun(200, 390) { 250, 300, 350 }
             );
         }
 
@@ -2960,7 +2960,7 @@ namespace ReactiveTests.Tests
             );
 
             scheduler.Timers.AssertEqual(
-                new TimerRun(200, 300) { 250, 300 }
+                new TimerRun(200, 300) { 250 }
             );
         }
 

--- a/Rx.NET/Source/Tests.System.Reactive/Tests/Linq/WeakObservableTest.cs
+++ b/Rx.NET/Source/Tests.System.Reactive/Tests/Linq/WeakObservableTest.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using Microsoft.Reactive.Testing;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text;
+
+
+// https://github.com/Reactive-Extensions/Rx.NET/issues/134
+
+namespace ReactiveTests.Tests
+{
+    [TestClass]
+    public class WeakObservableTest : ReactiveTest
+    {
+        [TestMethod]
+        public void ToWeakObservable_Complete()
+        {
+            var scheduler = new TestScheduler();
+
+            long lastItem = -1;
+            var xs = Observable.Interval(TimeSpan.FromSeconds(1), scheduler);
+            xs.ToWeakObservable()
+                .Subscribe(m => lastItem = m);
+
+            scheduler.AdvanceBy(TimeSpan.FromSeconds(2));
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            scheduler.AdvanceBy(TimeSpan.FromSeconds(2));
+
+            Assert.AreEqual(1, lastItem);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #134

When the source observable complete
the Sample immediately sending the last value 
and dispose the periodic schedule
rather than waiting for the periodic schedule event 
(which may take take long)


