### PR TITLE
Fix Ix Catch method invalid behaviour with Array.

### DIFF
--- a/Ix.NET/Source/System.Interactive/EnumerableEx.Exceptions.cs
+++ b/Ix.NET/Source/System.Interactive/EnumerableEx.Exceptions.cs
@@ -37,13 +37,11 @@ namespace System.Linq
             {
                 while (true)
                 {
-                    var b = default(bool);
                     var c = default(TSource);
 
                     try
                     {
-                        b = e.MoveNext();
-                        if (!b)
+                        if (!e.MoveNext())
                             break;
 
                         c = e.Current;
@@ -122,13 +120,11 @@ namespace System.Linq
 
                     while (true)
                     {
-                        var b = default(bool);
                         var c = default(TSource);
 
                         try
                         {
-                            b = e.MoveNext();
-                            if (!b)
+                            if (!e.MoveNext())
                                 break;
 
                             c = e.Current;

--- a/Ix.NET/Source/System.Interactive/EnumerableEx.Exceptions.cs
+++ b/Ix.NET/Source/System.Interactive/EnumerableEx.Exceptions.cs
@@ -43,6 +43,9 @@ namespace System.Linq
                     try
                     {
                         b = e.MoveNext();
+                        if (!b)
+                            break;
+
                         c = e.Current;
                     }
                     catch (TException ex)
@@ -50,9 +53,6 @@ namespace System.Linq
                         err = handler(ex);
                         break;
                     }
-
-                    if (!b)
-                        break;
 
                     yield return c;
                 }
@@ -128,6 +128,9 @@ namespace System.Linq
                         try
                         {
                             b = e.MoveNext();
+                            if (!b)
+                                break;
+
                             c = e.Current;
                         }
                         catch (Exception ex)
@@ -135,9 +138,6 @@ namespace System.Linq
                             error = ex;
                             break;
                         }
-
-                        if (!b)
-                            break;
 
                         yield return c;
                     }

--- a/Ix.NET/Source/Tests/Tests.Exceptions.cs
+++ b/Ix.NET/Source/Tests/Tests.Exceptions.cs
@@ -132,7 +132,7 @@ namespace Tests
         {
             var xs = new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
             var res = xs.Catch<int, MyException>(e => { Assert.Fail(); return new[] { 42 }; });
-            Assert.IsTrue(xs.SequenceEqual(res));
+            Assert.True(xs.SequenceEqual(res));
         }
 
         [Fact]
@@ -140,7 +140,7 @@ namespace Tests
         {
             var xss = new[] { new[] { 0, 1, 2, 3, 4 }, new[] { 5, 6, 7, 8, 9 } };
             var res = EnumerableEx.Catch(xss);
-            Assert.IsTrue(res.SequenceEqual(Enumerable.Range(0, 5)));
+            Assert.True(res.SequenceEqual(Enumerable.Range(0, 5)));
         }
 
         [Fact]
@@ -148,7 +148,7 @@ namespace Tests
         {
             var xss = new[] { new[] { 0, 1, 2, 3, 4 }, new[] { 5, 6, 7, 8, 9 } };
             var res = xss.Catch();
-            Assert.IsTrue(res.SequenceEqual(Enumerable.Range(0, 5)));
+            Assert.True(res.SequenceEqual(Enumerable.Range(0, 5)));
         }
 
         [Fact]
@@ -156,7 +156,7 @@ namespace Tests
         {
             var xss = new[] { new[] { 0, 1, 2, 3, 4 }, new[] { 5, 6, 7, 8, 9 } };
             var res = xss[0].Catch(xss[1]);
-            Assert.IsTrue(res.SequenceEqual(Enumerable.Range(0, 5)));
+            Assert.True(res.SequenceEqual(Enumerable.Range(0, 5)));
         }
 
         [Fact]
@@ -164,7 +164,7 @@ namespace Tests
         {
             var xss = new[] { new[] { 0, 1, 2, 3, 4 }.Concat(EnumerableEx.Throw<int>(new MyException())), new[] { 5, 6, 7, 8, 9 } };
             var res = EnumerableEx.Catch(xss);
-            Assert.IsTrue(res.SequenceEqual(Enumerable.Range(0, 10)));
+            Assert.True(res.SequenceEqual(Enumerable.Range(0, 10)));
         }
 
         [Fact]
@@ -172,7 +172,7 @@ namespace Tests
         {
             var xss = new[] { new[] { 0, 1, 2, 3, 4 }.Concat(EnumerableEx.Throw<int>(new MyException())), new[] { 5, 6, 7, 8, 9 } };
             var res = xss.Catch();
-            Assert.IsTrue(res.SequenceEqual(Enumerable.Range(0, 10)));
+            Assert.True(res.SequenceEqual(Enumerable.Range(0, 10)));
         }
 
         [Fact]
@@ -180,7 +180,7 @@ namespace Tests
         {
             var xss = new[] { new[] { 0, 1, 2, 3, 4 }.Concat(EnumerableEx.Throw<int>(new MyException())), new[] { 5, 6, 7, 8, 9 } };
             var res = xss[0].Catch(xss[1]);
-            Assert.IsTrue(res.SequenceEqual(Enumerable.Range(0, 10)));
+            Assert.True(res.SequenceEqual(Enumerable.Range(0, 10)));
         }
 
         [Fact]

--- a/Ix.NET/Source/Tests/Tests.Exceptions.cs
+++ b/Ix.NET/Source/Tests/Tests.Exceptions.cs
@@ -127,7 +127,7 @@ namespace Tests
             AssertThrows<MyException>(() => e.MoveNext(), ex => ex == e3);
         }
 
-        [TestMethod]
+        [Fact]
         public void Catch4_Array()
         {
             var xs = new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
@@ -135,7 +135,7 @@ namespace Tests
             Assert.IsTrue(xs.SequenceEqual(res));
         }
 
-        [TestMethod]
+        [Fact]
         public void Catch5_Array()
         {
             var xss = new[] { new[] { 0, 1, 2, 3, 4 }, new[] { 5, 6, 7, 8, 9 } };
@@ -143,7 +143,7 @@ namespace Tests
             Assert.IsTrue(res.SequenceEqual(Enumerable.Range(0, 5)));
         }
 
-        [TestMethod]
+        [Fact]
         public void Catch6_Array()
         {
             var xss = new[] { new[] { 0, 1, 2, 3, 4 }, new[] { 5, 6, 7, 8, 9 } };
@@ -151,7 +151,7 @@ namespace Tests
             Assert.IsTrue(res.SequenceEqual(Enumerable.Range(0, 5)));
         }
 
-        [TestMethod]
+        [Fact]
         public void Catch7_Array()
         {
             var xss = new[] { new[] { 0, 1, 2, 3, 4 }, new[] { 5, 6, 7, 8, 9 } };
@@ -159,7 +159,7 @@ namespace Tests
             Assert.IsTrue(res.SequenceEqual(Enumerable.Range(0, 5)));
         }
 
-        [TestMethod]
+        [Fact]
         public void Catch8_Array()
         {
             var xss = new[] { new[] { 0, 1, 2, 3, 4 }.Concat(EnumerableEx.Throw<int>(new MyException())), new[] { 5, 6, 7, 8, 9 } };
@@ -167,7 +167,7 @@ namespace Tests
             Assert.IsTrue(res.SequenceEqual(Enumerable.Range(0, 10)));
         }
 
-        [TestMethod]
+        [Fact]
         public void Catch9_Array()
         {
             var xss = new[] { new[] { 0, 1, 2, 3, 4 }.Concat(EnumerableEx.Throw<int>(new MyException())), new[] { 5, 6, 7, 8, 9 } };
@@ -175,7 +175,7 @@ namespace Tests
             Assert.IsTrue(res.SequenceEqual(Enumerable.Range(0, 10)));
         }
 
-        [TestMethod]
+        [Fact]
         public void Catch10_Array()
         {
             var xss = new[] { new[] { 0, 1, 2, 3, 4 }.Concat(EnumerableEx.Throw<int>(new MyException())), new[] { 5, 6, 7, 8, 9 } };
@@ -183,7 +183,7 @@ namespace Tests
             Assert.IsTrue(res.SequenceEqual(Enumerable.Range(0, 10)));
         }
 
-        [TestMethod]
+        [Fact]
         public void Catch11_Array()
         {
             var e1 = new MyException();

--- a/Ix.NET/Source/Tests/Tests.Exceptions.cs
+++ b/Ix.NET/Source/Tests/Tests.Exceptions.cs
@@ -127,6 +127,85 @@ namespace Tests
             AssertThrows<MyException>(() => e.MoveNext(), ex => ex == e3);
         }
 
+        [TestMethod]
+        public void Catch4_Array()
+        {
+            var xs = new[] { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+            var res = xs.Catch<int, MyException>(e => { Assert.Fail(); return new[] { 42 }; });
+            Assert.IsTrue(xs.SequenceEqual(res));
+        }
+
+        [TestMethod]
+        public void Catch5_Array()
+        {
+            var xss = new[] { new[] { 0, 1, 2, 3, 4 }, new[] { 5, 6, 7, 8, 9 } };
+            var res = EnumerableEx.Catch(xss);
+            Assert.IsTrue(res.SequenceEqual(Enumerable.Range(0, 5)));
+        }
+
+        [TestMethod]
+        public void Catch6_Array()
+        {
+            var xss = new[] { new[] { 0, 1, 2, 3, 4 }, new[] { 5, 6, 7, 8, 9 } };
+            var res = xss.Catch();
+            Assert.IsTrue(res.SequenceEqual(Enumerable.Range(0, 5)));
+        }
+
+        [TestMethod]
+        public void Catch7_Array()
+        {
+            var xss = new[] { new[] { 0, 1, 2, 3, 4 }, new[] { 5, 6, 7, 8, 9 } };
+            var res = xss[0].Catch(xss[1]);
+            Assert.IsTrue(res.SequenceEqual(Enumerable.Range(0, 5)));
+        }
+
+        [TestMethod]
+        public void Catch8_Array()
+        {
+            var xss = new[] { new[] { 0, 1, 2, 3, 4 }.Concat(EnumerableEx.Throw<int>(new MyException())), new[] { 5, 6, 7, 8, 9 } };
+            var res = EnumerableEx.Catch(xss);
+            Assert.IsTrue(res.SequenceEqual(Enumerable.Range(0, 10)));
+        }
+
+        [TestMethod]
+        public void Catch9_Array()
+        {
+            var xss = new[] { new[] { 0, 1, 2, 3, 4 }.Concat(EnumerableEx.Throw<int>(new MyException())), new[] { 5, 6, 7, 8, 9 } };
+            var res = xss.Catch();
+            Assert.IsTrue(res.SequenceEqual(Enumerable.Range(0, 10)));
+        }
+
+        [TestMethod]
+        public void Catch10_Array()
+        {
+            var xss = new[] { new[] { 0, 1, 2, 3, 4 }.Concat(EnumerableEx.Throw<int>(new MyException())), new[] { 5, 6, 7, 8, 9 } };
+            var res = xss[0].Catch(xss[1]);
+            Assert.IsTrue(res.SequenceEqual(Enumerable.Range(0, 10)));
+        }
+
+        [TestMethod]
+        public void Catch11_Array()
+        {
+            var e1 = new MyException();
+            var ex1 = EnumerableEx.Throw<int>(e1);
+
+            var e2 = new MyException();
+            var ex2 = EnumerableEx.Throw<int>(e2);
+
+            var e3 = new MyException();
+            var ex3 = EnumerableEx.Throw<int>(e3);
+
+            var xss = new[] { new[] { 0, 1 }.Concat(ex1), new[] { 2, 3 }.Concat(ex2), ex3 };
+            var res = xss.Catch();
+
+            var e = res.GetEnumerator();
+            HasNext(e, 0);
+            HasNext(e, 1);
+            HasNext(e, 2);
+            HasNext(e, 3);
+            AssertThrows<MyException>(() => e.MoveNext(), ex => ex == e3);
+        }
+
         [Fact]
         public void Finally_Arguments()
         {


### PR DESCRIPTION
I fixed Ix Catch methods with Array.

At 2252cb4, next test passes.

```csharp
[TestMethod]
public void Catch5()
{
    var xss = new[] { Enumerable.Range(0, 5), Enumerable.Range(5, 5) };
    var res = EnumerableEx.Catch(xss);
    Assert.IsTrue(res.SequenceEqual(Enumerable.Range(0, 5)));
}
```

But next test failed.

```csharp
[TestMethod]
public void Catch5_Array()
{
    var xss = new[] { new[] { 0, 1, 2, 3, 4 }, new[] { 5, 6, 7, 8, 9 } };
    var res = EnumerableEx.Catch(xss);
    Assert.IsTrue(res.SequenceEqual(Enumerable.Range(0, 5)));
}
```

`IEnumerator<T>` `Current` property when `IEnumerator<T>` `MoveNext()` return false is undefined.

Array throws Exception.`List<T>` returns defaualt(T).

Unexpected throwing exceptions are happen at [here](https://github.com/Reactive-Extensions/Rx.NET/blob/master/Ix.NET/Source/System.Interactive/EnumerableEx.Exceptions.cs#L44) and [here](https://github.com/Reactive-Extensions/Rx.NET/blob/master/Ix.NET/Source/System.Interactive/EnumerableEx.Exceptions.cs#L129) with Array.

I fixed it.
