### PR TITLE
Remove portable- from NuSpecs 

### DIFF
--- a/Ix.NET/Source/NuSpecs/System.Interactive.Async.Providers.nuspec
+++ b/Ix.NET/Source/NuSpecs/System.Interactive.Async.Providers.nuspec
@@ -39,6 +39,5 @@
   </metadata>
   <files>
     <file src="..\System.Interactive.Async.Providers\bin\$configuration$\**\System.Interactive.Async.Providers.*" exclude="**\*.deps.json" target="lib" />
-    <file src="..\System.Interactive.Async.Providers\bin\$configuration$\netstandard1.0\System.Interactive.Async.Providers.*" exclude="**\*.deps.json" target="lib\portable-win8+net45+wp8+wpa81" />
   </files>
 </package>

--- a/Ix.NET/Source/NuSpecs/System.Interactive.Async.nuspec
+++ b/Ix.NET/Source/NuSpecs/System.Interactive.Async.nuspec
@@ -33,6 +33,5 @@
   </metadata>
   <files>
     <file src="..\System.Interactive.Async\bin\$configuration$\**\System.Interactive.Async.*" exclude="**\*.deps.json" target="lib" />
-    <file src="..\System.Interactive.Async\bin\$configuration$\netstandard1.0\System.Interactive.Async.*" exclude="**\*.deps.json" target="lib\portable-win8+net45+wp8+wpa81" />
   </files>
 </package>

--- a/Ix.NET/Source/NuSpecs/System.Interactive.Providers.nuspec
+++ b/Ix.NET/Source/NuSpecs/System.Interactive.Providers.nuspec
@@ -39,6 +39,5 @@
   </metadata>
   <files>
     <file src="..\System.Interactive.Providers\bin\$configuration$\**\System.Interactive.Providers.*" exclude="**\*.deps.json" target="lib" />
-    <file src="..\System.Interactive.Providers\bin\$configuration$\netstandard1.0\System.Interactive.Providers.*" exclude="**\*.deps.json" target="lib\portable-win8+net45+wp8+wpa81" />
   </files>
 </package>

--- a/Ix.NET/Source/NuSpecs/System.Interactive.nuspec
+++ b/Ix.NET/Source/NuSpecs/System.Interactive.nuspec
@@ -33,6 +33,5 @@
   </metadata>
   <files>
     <file src="..\System.Interactive\bin\$configuration$\**\System.Interactive.*" exclude="**\*.deps.json" target="lib" />
-    <file src="..\System.Interactive\bin\$configuration$\netstandard1.0\System.Interactive.*" exclude="**\*.deps.json" target="lib\portable-win8+net45+wp8+wpa81" />
   </files>
 </package>

--- a/Ix.NET/Source/build-new.ps1
+++ b/Ix.NET/Source/build-new.ps1
@@ -65,7 +65,7 @@ $nuspecs = ls $nuspecDir\*.nuspec | Select -ExpandProperty FullName
 New-Item -ItemType Directory -Force -Path .\artifacts
 
 foreach ($nuspec in $nuspecs) {
-   .\nuget pack $nuspec -symbols -Version $version -Properties "Configuration=$configuration" -MinClientVersion 2.8.6 -outputdirectory .\artifacts
+   .\nuget pack $nuspec -symbols -Version $version -Properties "Configuration=$configuration" -MinClientVersion 2.12 -outputdirectory .\artifacts
 }
 
 Write-Host "Running tests" -Foreground Green

--- a/Rx.NET/Source/NuSpecs/Microsoft.Reactive.Testing.nuspec
+++ b/Rx.NET/Source/NuSpecs/Microsoft.Reactive.Testing.nuspec
@@ -76,6 +76,5 @@
   </metadata>
   <files>
     <file src="..\Microsoft.Reactive.Testing\bin\$configuration$\**\Microsoft.Reactive.Testing.*" exclude="**\*.deps.json" target="lib" />
-    <file src="..\Microsoft.Reactive.Testing\bin\$configuration$\netstandard1.0\Microsoft.Reactive.Testing.*" exclude="**\*.deps.json" target="lib\portable-win8+net45+wp8+wpa81" />
   </files>
 </package>

--- a/Rx.NET/Source/NuSpecs/System.Reactive.Core.nuspec
+++ b/Rx.NET/Source/NuSpecs/System.Reactive.Core.nuspec
@@ -118,7 +118,5 @@
   </metadata>
   <files>
     <file src="..\System.Reactive.Core\bin\$configuration$\**\System.Reactive.Core.*" exclude="**\*.deps.json" target="lib" />
-    <file src="..\System.Reactive.Core\bin\$configuration$\netstandard1.0\System.Reactive.Core.*" exclude="**\*.deps.json" target="lib\portable-win8+net45+wp8+wpa81" />
-    <file src="..\System.Reactive.Core\bin\$configuration$\netstandard1.1\System.Reactive.Core.*" exclude="**\*.deps.json" target="lib\portable-win8+net45+wpa81" />
   </files>
 </package>

--- a/Rx.NET/Source/NuSpecs/System.Reactive.Experimental.nuspec
+++ b/Rx.NET/Source/NuSpecs/System.Reactive.Experimental.nuspec
@@ -63,6 +63,5 @@
   </metadata>
   <files>
     <file src="..\System.Reactive.Experimental\bin\$configuration$\**\System.Reactive.Experimental.*" exclude="**\*.deps.json" target="lib" />
-    <file src="..\System.Reactive.Experimental\bin\$configuration$\netstandard1.0\System.Reactive.Experimental.*" exclude="**\*.deps.json" target="lib\portable-win8+net45+wp8+wpa81" />
   </files>
 </package>

--- a/Rx.NET/Source/NuSpecs/System.Reactive.Interfaces.nuspec
+++ b/Rx.NET/Source/NuSpecs/System.Reactive.Interfaces.nuspec
@@ -25,6 +25,5 @@
   </metadata>
   <files>
     <file src="..\System.Reactive.Interfaces\bin\$configuration$\**\System.Reactive.Interfaces.*" exclude="**\*.deps.json" target="lib" />
-    <file src="..\System.Reactive.Interfaces\bin\$configuration$\netstandard1.0\System.Reactive.Interfaces.*" exclude="**\*.deps.json" target="lib\portable-win8+net45+wp8+wpa81" />
   </files>
 </package>

--- a/Rx.NET/Source/NuSpecs/System.Reactive.Linq.nuspec
+++ b/Rx.NET/Source/NuSpecs/System.Reactive.Linq.nuspec
@@ -83,7 +83,5 @@
   </metadata>
   <files>
     <file src="..\System.Reactive.Linq\bin\$configuration$\**\System.Reactive.Linq.*" exclude="**\*.deps.json" target="lib" />
-    <file src="..\System.Reactive.Linq\bin\$configuration$\netstandard1.0\System.Reactive.Linq.*" exclude="**\*.deps.json" target="lib\portable-win8+net45+wp8+wpa81" />
-    <file src="..\System.Reactive.Linq\bin\$configuration$\netstandard1.1\System.Reactive.Linq.*" exclude="**\*.deps.json" target="lib\portable-win8+net45+wpa81" />
   </files>
 </package>

--- a/Rx.NET/Source/NuSpecs/System.Reactive.Observable.Aliases.nuspec
+++ b/Rx.NET/Source/NuSpecs/System.Reactive.Observable.Aliases.nuspec
@@ -45,6 +45,5 @@
   </metadata>
   <files>
     <file src="..\System.Reactive.Observable.Aliases\bin\$configuration$\**\System.Reactive.Observable.Aliases.*" exclude="**\*.deps.json" target="lib" />
-    <file src="..\System.Reactive.Observable.Aliases\bin\$configuration$\netstandard1.0\System.Reactive.Observable.Aliases.*" exclude="**\*.deps.json" target="lib\portable-win8+net45+wp8+wpa81" />
   </files>
 </package>

--- a/Rx.NET/Source/NuSpecs/System.Reactive.PlatformServices.nuspec
+++ b/Rx.NET/Source/NuSpecs/System.Reactive.PlatformServices.nuspec
@@ -99,6 +99,5 @@
   </metadata>
   <files>
     <file src="..\System.Reactive.PlatformServices\bin\$configuration$\**\System.Reactive.PlatformServices.*" exclude="**\*.deps.json" target="lib" />
-    <file src="..\System.Reactive.PlatformServices\bin\$configuration$\netstandard1.0\System.Reactive.PlatformServices.*" exclude="**\*.deps.json" target="lib\portable-win8+net45+wp8+wpa81" />
   </files>
 </package>

--- a/Rx.NET/Source/NuSpecs/System.Reactive.Providers.nuspec
+++ b/Rx.NET/Source/NuSpecs/System.Reactive.Providers.nuspec
@@ -64,6 +64,5 @@
   </metadata>
   <files>
     <file src="..\System.Reactive.Providers\bin\$configuration$\**\System.Reactive.Providers.*" exclude="**\*.deps.json" target="lib" />
-    <file src="..\System.Reactive.Providers\bin\$configuration$\netstandard1.0\System.Reactive.Providers.*" exclude="**\*.deps.json" target="lib\portable-win8+net45+wp8+wpa81" />
   </files>
 </package>

--- a/Rx.NET/Source/build-new.ps1
+++ b/Rx.NET/Source/build-new.ps1
@@ -76,7 +76,7 @@ foreach ($nuspec in $nuspecs)
     $symbolSwitch = ""
   }
    
-   .\nuget pack $nuspec $symbolSwitch -Version $version -Properties "Configuration=$configuration" -MinClientVersion 2.8.6 -outputdirectory .\artifacts
+   .\nuget pack $nuspec $symbolSwitch -Version $version -Properties "Configuration=$configuration" -MinClientVersion 2.12 -outputdirectory .\artifacts
 }
 
 Write-Host "Running tests" -Foreground Green


### PR DESCRIPTION
This addresses #190 by removing `portable-` lib folders and relying on NuGet 2.12's support for `netstandard1.0` in VS 2012/2013