### PR TITLE
Ensure good experience for packages.config users

### DIFF
--- a/Ix.NET/Source/NuSpecs/System.Interactive.Async.Providers.nuspec
+++ b/Ix.NET/Source/NuSpecs/System.Interactive.Async.Providers.nuspec
@@ -14,7 +14,7 @@
     <language>en-US</language>
     <tags>Ix Interactive Extensions Enumerable Async</tags>
     <dependencies>
-      <group>
+      <group targetFramework="portable-net45+win8+wp8+wpa81">
         <dependency id="System.Interactive.Async" version="$version$" />
       </group>
       <group targetFramework="netstandard1.0">
@@ -30,7 +30,7 @@
       </group>
       <group targetFramework="net45">
         <dependency id="System.Interactive.Async" version="$version$" />
-      </group>
+      </group>      
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System" targetFramework="net45" />
@@ -39,5 +39,6 @@
   </metadata>
   <files>
     <file src="..\System.Interactive.Async.Providers\bin\$configuration$\**\System.Interactive.Async.Providers.*" exclude="**\*.deps.json" target="lib" />
+    <file src="..\System.Interactive.Async.Providers\bin\$configuration$\netstandard1.0\System.Interactive.Async.Providers.*" exclude="**\*.deps.json" target="lib\portable-net45+win8+wp8+wpa81" />
   </files>
 </package>

--- a/Ix.NET/Source/NuSpecs/System.Interactive.Async.nuspec
+++ b/Ix.NET/Source/NuSpecs/System.Interactive.Async.nuspec
@@ -29,9 +29,11 @@
         <dependency id="System.Threading.Tasks" version="4.0.11" />
       </group>
       <group targetFramework="net45" />
+      <group targetFramework="portable-net45+win8+wp8+wpa81" />
     </dependencies>
   </metadata>
   <files>
     <file src="..\System.Interactive.Async\bin\$configuration$\**\System.Interactive.Async.*" exclude="**\*.deps.json" target="lib" />
+    <file src="..\System.Interactive.Async\bin\$configuration$\netstandard1.0\System.Interactive.Async.*" exclude="**\*.deps.json" target="lib\portable-net45+win8+wp8+wpa81" />
   </files>
 </package>

--- a/Ix.NET/Source/NuSpecs/System.Interactive.Providers.nuspec
+++ b/Ix.NET/Source/NuSpecs/System.Interactive.Providers.nuspec
@@ -14,7 +14,7 @@
     <language>en-US</language>
     <tags>Ix Interactive Extensions Enumerable</tags>
     <dependencies>
-      <group>
+      <group targetFramework="portable-net45+win8+wp8+wpa81">
         <dependency id="System.Interactive" version="$version$" />
       </group>
       <group targetFramework="netstandard1.0">
@@ -39,5 +39,6 @@
   </metadata>
   <files>
     <file src="..\System.Interactive.Providers\bin\$configuration$\**\System.Interactive.Providers.*" exclude="**\*.deps.json" target="lib" />
+    <file src="..\System.Interactive.Providers\bin\$configuration$\netstandard1.0\System.Interactive.Providers.*" exclude="**\*.deps.json" target="lib\portable-net45+win8+wp8+wpa81" />
   </files>
 </package>

--- a/Ix.NET/Source/NuSpecs/System.Interactive.nuspec
+++ b/Ix.NET/Source/NuSpecs/System.Interactive.nuspec
@@ -17,7 +17,7 @@
       <frameworkAssembly assemblyName="System" targetFramework="net45" />
       <frameworkAssembly assemblyName="System.Core" targetFramework="net45" />
     </frameworkAssemblies>
-    <dependencies>
+    <dependencies>      
       <group targetFramework="netstandard1.0">
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11" />
@@ -29,9 +29,11 @@
         <dependency id="System.Threading.Tasks" version="4.0.11" />
       </group>
       <group targetFramework="net45" />
+      <group targetFramework="portable-net45+win8+wp8+wpa81" />
     </dependencies>
   </metadata>
   <files>
     <file src="..\System.Interactive\bin\$configuration$\**\System.Interactive.*" exclude="**\*.deps.json" target="lib" />
+    <file src="..\System.Interactive\bin\$configuration$\netstandard1.0\System.Interactive.*" exclude="**\*.deps.json" target="lib\portable-net45+win8+wp8+wpa81" />
   </files>
 </package>

--- a/Ix.NET/Source/build-new.ps1
+++ b/Ix.NET/Source/build-new.ps1
@@ -65,7 +65,7 @@ $nuspecs = ls $nuspecDir\*.nuspec | Select -ExpandProperty FullName
 New-Item -ItemType Directory -Force -Path .\artifacts
 
 foreach ($nuspec in $nuspecs) {
-   .\nuget pack $nuspec -symbols -Version $version -Properties "Configuration=$configuration" -MinClientVersion 2.12 -outputdirectory .\artifacts
+   .\nuget pack $nuspec -symbols -Version $version -Properties "Configuration=$configuration" -MinClientVersion 2.8.6 -outputdirectory .\artifacts
 }
 
 Write-Host "Running tests" -Foreground Green

--- a/Rx.NET/Source/NuSpecs/Microsoft.Reactive.Testing.nuspec
+++ b/Rx.NET/Source/NuSpecs/Microsoft.Reactive.Testing.nuspec
@@ -15,9 +15,10 @@
     <language>en-US</language>
     <tags>Rx Reactive Extensions Observable LINQ Events</tags>
     <dependencies>
-      <group>
+      <group targetFramework="portable-net45+win8+wp8+wpa81">
         <dependency id="System.Reactive.Linq" version="$version$" />
         <dependency id="System.Reactive.PlatformServices" version="$version$" />
+        <dependency id="xunit.assert" version="2.1.0" />
       </group>
       <group targetFramework="netcore451">
         <dependency id="System.Reactive.Linq" version="$version$" />
@@ -76,5 +77,6 @@
   </metadata>
   <files>
     <file src="..\Microsoft.Reactive.Testing\bin\$configuration$\**\Microsoft.Reactive.Testing.*" exclude="**\*.deps.json" target="lib" />
+    <file src="..\Microsoft.Reactive.Testing\bin\$configuration$\netstandard1.0\Microsoft.Reactive.Testing.*" exclude="**\*.deps.json" target="lib\portable-net45+win8+wp8+wpa81" />
   </files>
 </package>

--- a/Rx.NET/Source/NuSpecs/System.Reactive.Core.nuspec
+++ b/Rx.NET/Source/NuSpecs/System.Reactive.Core.nuspec
@@ -15,7 +15,10 @@
     <language>en-US</language>
     <tags>Rx Reactive Extensions Observable LINQ Events</tags>
     <dependencies>
-      <group>
+      <group targetFramework="portable-net45+win8+wp8+wpa81">
+        <dependency id="System.Reactive.Interfaces" version="$version$" />
+      </group>
+      <group targetFramework="portable-net45+win8+wpa81">
         <dependency id="System.Reactive.Interfaces" version="$version$" />
       </group>
       <group targetFramework="netstandard1.0">
@@ -118,5 +121,7 @@
   </metadata>
   <files>
     <file src="..\System.Reactive.Core\bin\$configuration$\**\System.Reactive.Core.*" exclude="**\*.deps.json" target="lib" />
+    <file src="..\System.Reactive.Core\bin\$configuration$\netstandard1.0\System.Reactive.Core.*" exclude="**\*.deps.json" target="lib\portable-net45+win8+wp8+wpa81" />
+    <file src="..\System.Reactive.Core\bin\$configuration$\netstandard1.1\System.Reactive.Core.*" exclude="**\*.deps.json" target="lib\portable-net45+win8+wpa81" />
   </files>
 </package>

--- a/Rx.NET/Source/NuSpecs/System.Reactive.Experimental.nuspec
+++ b/Rx.NET/Source/NuSpecs/System.Reactive.Experimental.nuspec
@@ -15,7 +15,7 @@
     <language>en-US</language>
     <tags>Rx Reactive Extensions Observable LINQ Events</tags>
     <dependencies>
-      <group>
+      <group targetFramework="portable-net45+win8+wp8+wpa81">
         <dependency id="System.Reactive.Interfaces" version="$version$" />
         <dependency id="System.Reactive.Core" version="$version$" />
         <dependency id="System.Reactive.Linq" version="$version$" />
@@ -63,5 +63,6 @@
   </metadata>
   <files>
     <file src="..\System.Reactive.Experimental\bin\$configuration$\**\System.Reactive.Experimental.*" exclude="**\*.deps.json" target="lib" />
+    <file src="..\System.Reactive.Experimental\bin\$configuration$\netstandard1.0\System.Reactive.Experimental.*" exclude="**\*.deps.json" target="lib\portable-net45+win8+wp8+wpa81" />
   </files>
 </package>

--- a/Rx.NET/Source/NuSpecs/System.Reactive.Interfaces.nuspec
+++ b/Rx.NET/Source/NuSpecs/System.Reactive.Interfaces.nuspec
@@ -21,9 +21,11 @@
         <dependency id="System.Runtime" version="4.1.0" />
       </group>
       <group targetFramework="net45" />
+      <group targetFramework="portable-net45+win8+wp8+wpa81" />
     </dependencies>
   </metadata>
   <files>
     <file src="..\System.Reactive.Interfaces\bin\$configuration$\**\System.Reactive.Interfaces.*" exclude="**\*.deps.json" target="lib" />
+    <file src="..\System.Reactive.Interfaces\bin\$configuration$\netstandard1.0\System.Reactive.Interfaces.*" exclude="**\*.deps.json" target="lib\portable-net45+win8+wp8+wpa81" />
   </files>
 </package>

--- a/Rx.NET/Source/NuSpecs/System.Reactive.Linq.nuspec
+++ b/Rx.NET/Source/NuSpecs/System.Reactive.Linq.nuspec
@@ -15,7 +15,11 @@
     <language>en-US</language>
     <tags>Rx Reactive Extensions Observable LINQ Events</tags>
     <dependencies>
-      <group>
+      <group targetFramework="portable-net45+win8+wp8+wpa81">
+        <dependency id="System.Reactive.Interfaces" version="$version$" />
+        <dependency id="System.Reactive.Core" version="$version$" />
+      </group>
+      <group targetFramework="portable-net45+win8+wpa81">
         <dependency id="System.Reactive.Interfaces" version="$version$" />
         <dependency id="System.Reactive.Core" version="$version$" />
       </group>
@@ -83,5 +87,7 @@
   </metadata>
   <files>
     <file src="..\System.Reactive.Linq\bin\$configuration$\**\System.Reactive.Linq.*" exclude="**\*.deps.json" target="lib" />
+    <file src="..\System.Reactive.Linq\bin\$configuration$\netstandard1.0\System.Reactive.Linq.*" exclude="**\*.deps.json" target="lib\portable-net45+win8+wp8+wpa81" />
+    <file src="..\System.Reactive.Linq\bin\$configuration$\netstandard1.1\System.Reactive.Linq.*" exclude="**\*.deps.json" target="lib\portable-net45+win8+wpa81" />
   </files>
 </package>

--- a/Rx.NET/Source/NuSpecs/System.Reactive.Observable.Aliases.nuspec
+++ b/Rx.NET/Source/NuSpecs/System.Reactive.Observable.Aliases.nuspec
@@ -15,7 +15,7 @@
     <language>en-US</language>
     <tags>Rx Reactive Extensions Observable LINQ Events</tags>
     <dependencies>
-      <group>
+      <group targetFramework="portable-net45+win8+wp8+wpa81">
         <dependency id="System.Reactive" version="$version$" />
         <dependency id="System.Reactive.Providers" version="$version$" />
       </group>
@@ -45,5 +45,6 @@
   </metadata>
   <files>
     <file src="..\System.Reactive.Observable.Aliases\bin\$configuration$\**\System.Reactive.Observable.Aliases.*" exclude="**\*.deps.json" target="lib" />
+    <file src="..\System.Reactive.Observable.Aliases\bin\$configuration$\netstandard1.0\System.Reactive.Observable.Aliases.*" exclude="**\*.deps.json" target="lib\portable-net45+win8+wp8+wpa81" />
   </files>
 </package>

--- a/Rx.NET/Source/NuSpecs/System.Reactive.PlatformServices.nuspec
+++ b/Rx.NET/Source/NuSpecs/System.Reactive.PlatformServices.nuspec
@@ -15,7 +15,7 @@
     <language>en-US</language>
     <tags>Rx Reactive Extensions Observable LINQ Events</tags>
     <dependencies>
-      <group>
+      <group targetFramework="portable-net45+win8+wp8+wpa81">
         <dependency id="System.Reactive.Interfaces" version="$version$" />
         <dependency id="System.Reactive.Core" version="$version$" />
       </group>
@@ -99,5 +99,6 @@
   </metadata>
   <files>
     <file src="..\System.Reactive.PlatformServices\bin\$configuration$\**\System.Reactive.PlatformServices.*" exclude="**\*.deps.json" target="lib" />
+    <file src="..\System.Reactive.PlatformServices\bin\$configuration$\netstandard1.0\System.Reactive.PlatformServices.*" exclude="**\*.deps.json" target="lib\portable-net45+win8+wp8+wpa81" />
   </files>
 </package>

--- a/Rx.NET/Source/NuSpecs/System.Reactive.Providers.nuspec
+++ b/Rx.NET/Source/NuSpecs/System.Reactive.Providers.nuspec
@@ -15,7 +15,7 @@
     <language>en-US</language>
     <tags>Rx Reactive Extensions Observable LINQ Events</tags>
     <dependencies>
-      <group>
+      <group targetFramework="portable-net45+win8+wp8+wpa81">
         <dependency id="System.Reactive" version="$version$" />
       </group>
       <group targetFramework="netstandard1.0">
@@ -64,5 +64,6 @@
   </metadata>
   <files>
     <file src="..\System.Reactive.Providers\bin\$configuration$\**\System.Reactive.Providers.*" exclude="**\*.deps.json" target="lib" />
+    <file src="..\System.Reactive.Providers\bin\$configuration$\netstandard1.0\System.Reactive.Providers.*" exclude="**\*.deps.json" target="lib\portable-net45+win8+wp8+wpa81" />
   </files>
 </package>

--- a/Rx.NET/Source/build-new.ps1
+++ b/Rx.NET/Source/build-new.ps1
@@ -76,7 +76,7 @@ foreach ($nuspec in $nuspecs)
     $symbolSwitch = ""
   }
    
-   .\nuget pack $nuspec $symbolSwitch -Version $version -Properties "Configuration=$configuration" -MinClientVersion 2.12 -outputdirectory .\artifacts
+   .\nuget pack $nuspec $symbolSwitch -Version $version -Properties "Configuration=$configuration" -MinClientVersion 2.8.6 -outputdirectory .\artifacts
 }
 
 Write-Host "Running tests" -Foreground Green


### PR DESCRIPTION
Put some dependency groups in that'll stop packages.config users from getting a lot of dependencies. Also ensures we work with NuGet 2.8.6 until 2.12 is available with netstandard support in VS 2012+