### PR TITLE
Fix spelling error in documentation comment.

### DIFF
--- a/Rx.NET/Source/System.Reactive.Linq/Reactive/Linq/Observable.Time.cs
+++ b/Rx.NET/Source/System.Reactive.Linq/Reactive/Linq/Observable.Time.cs
@@ -720,7 +720,7 @@ namespace System.Reactive.Linq
         }
 
         /// <summary>
-        /// Samples the source observable sequence using a samper observable sequence producing sampling ticks.
+        /// Samples the source observable sequence using a sampler observable sequence producing sampling ticks.
         /// Upon each sampling tick, the latest element (if any) in the source sequence during the last sampling interval is sent to the resulting sequence.
         /// </summary>
         /// <typeparam name="TSource">The type of the elements in the source sequence.</typeparam>


### PR DESCRIPTION
I fixed the "samper" typo in the XML documentation comment to correctly refer to the `sampler` function parameter.