### PR TITLE
VS environment cleanup

### DIFF
--- a/Ix.NET/Source/Ix.NET.sln
+++ b/Ix.NET/Source/Ix.NET.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.25402.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "System.Interactive", "System.Interactive\System.Interactive.xproj", "{FF97CD0F-8108-4B66-8A34-42190B459180}"
 EndProject
@@ -16,6 +16,11 @@ EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "System.Interactive.Tests", "Tests\System.Interactive.Tests.xproj", "{592E774E-D5BE-44C5-9E4D-E096BEC01552}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{B733D97A-F1ED-4FC3-BF8E-9AC47A89DE96}"
+	ProjectSection(SolutionItems) = preProject
+		build-new.ps1 = build-new.ps1
+		global.json = global.json
+		NuGet.Config = NuGet.Config
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "System.Interactive.Tests.Uwp.DeviceRunner", "System.Interactive.Tests.Uwp.DeviceRunner\System.Interactive.Tests.Uwp.DeviceRunner.csproj", "{ED118703-9773-4193-BC2A-966C29BC1A46}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/Ix.NET/Source/global.json
+++ b/Ix.NET/Source/global.json
@@ -1,4 +1,3 @@
 {
-    "sources": [ ".", "tests" ]
-    //"packages": "../../packages"
+  "projects": [ ".", "tests" ]
 }

--- a/Rx.NET/Source/global.json
+++ b/Rx.NET/Source/global.json
@@ -1,6 +1,3 @@
 {
-    "sources": [ ".", "Tests.System.Reactive" ],
-    "sdk": {
-      "version": "1.0.0-preview2-003093"
-  }
+  "projects": [ ".", "Tests.System.Reactive" ]
 }


### PR DESCRIPTION
After installing VS2015 Update 3 and the latest stable VS tooling for .NET Core, you'll probably see this message when opening the Rx.NET solution:

<img width="373" alt="screen shot 2016-06-30 at 5 03 57 pm" src="https://cloud.githubusercontent.com/assets/359239/16479611/cb2c7eec-3ee4-11e6-8021-6a66532db56a.png">

This PR makes the error go away, and also adds some of the solution-level changes to the Ix.NET solution so these have a consistent structure.

- [x] don't lock SDK versions

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/reactive-extensions/rx.net/208)
<!-- Reviewable:end -->
