### PR TITLE
Rename create methods

### DIFF
--- a/Ix.NET/Source/System.Interactive.Async/AsyncEnumerable.cs
+++ b/Ix.NET/Source/System.Interactive.Async/AsyncEnumerable.cs
@@ -22,7 +22,7 @@ namespace System.Linq
 
         public static IAsyncEnumerable<TValue> Empty<TValue>()
         {
-            return Create(() => Create<TValue>(
+            return CreateEnumerable(() => CreateEnumerator<TValue>(
                               ct => TaskExt.False,
                               () => { throw new InvalidOperationException(); },
                               () => { })
@@ -47,7 +47,7 @@ namespace System.Linq
 
         public static IAsyncEnumerable<TValue> Never<TValue>()
         {
-            return Create(() => Create<TValue>(
+            return CreateEnumerable(() => CreateEnumerator<TValue>(
                               (ct, tcs) => tcs.Task,
                               () => { throw new InvalidOperationException(); },
                               () => { })
@@ -65,7 +65,7 @@ namespace System.Linq
             if (exception == null)
                 throw new ArgumentNullException(nameof(exception));
 
-            return Create(() => Create<TValue>(
+            return CreateEnumerable(() => CreateEnumerator<TValue>(
                               ct => TaskExt.Throw<bool>(exception),
                               () => { throw new InvalidOperationException(); },
                               () => { })

--- a/Ix.NET/Source/System.Interactive.Async/AsyncEnumerable.cs
+++ b/Ix.NET/Source/System.Interactive.Async/AsyncEnumerable.cs
@@ -22,10 +22,11 @@ namespace System.Linq
 
         public static IAsyncEnumerable<TValue> Empty<TValue>()
         {
-            return CreateEnumerable(() => CreateEnumerator<TValue>(
-                              ct => TaskExt.False,
-                              () => { throw new InvalidOperationException(); },
-                              () => { })
+            return CreateEnumerable(
+                () => CreateEnumerator<TValue>(
+                    ct => TaskExt.False,
+                    () => { throw new InvalidOperationException(); },
+                    () => { })
             );
         }
 
@@ -47,10 +48,11 @@ namespace System.Linq
 
         public static IAsyncEnumerable<TValue> Never<TValue>()
         {
-            return CreateEnumerable(() => CreateEnumerator<TValue>(
-                              (ct, tcs) => tcs.Task,
-                              () => { throw new InvalidOperationException(); },
-                              () => { })
+            return CreateEnumerable(
+                () => CreateEnumerator<TValue>(
+                    (ct, tcs) => tcs.Task,
+                    () => { throw new InvalidOperationException(); },
+                    () => { })
             );
         }
 
@@ -65,10 +67,11 @@ namespace System.Linq
             if (exception == null)
                 throw new ArgumentNullException(nameof(exception));
 
-            return CreateEnumerable(() => CreateEnumerator<TValue>(
-                              ct => TaskExt.Throw<bool>(exception),
-                              () => { throw new InvalidOperationException(); },
-                              () => { })
+            return CreateEnumerable(
+                () => CreateEnumerator<TValue>(
+                    ct => TaskExt.Throw<bool>(exception),
+                    () => { throw new InvalidOperationException(); },
+                    () => { })
             );
         }
 

--- a/Ix.NET/Source/System.Interactive.Async/Buffer.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Buffer.cs
@@ -36,7 +36,7 @@ namespace System.Linq
 
         private static IAsyncEnumerable<IList<TSource>> Buffer_<TSource>(this IAsyncEnumerable<TSource> source, int count, int skip)
         {
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
 
@@ -89,7 +89,7 @@ namespace System.Linq
                                       return false;
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   f,
                                   () => current,
                                   d.Dispose,

--- a/Ix.NET/Source/System.Interactive.Async/Catch.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Catch.cs
@@ -21,7 +21,7 @@ namespace System.Linq
             if (handler == null)
                 throw new ArgumentNullException(nameof(handler));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
             {
                 var e = source.GetEnumerator();
 
@@ -58,7 +58,7 @@ namespace System.Linq
                                   .ConfigureAwait(false);
                 };
 
-                return Create(
+                return CreateEnumerator(
                     f,
                     () => e.Current,
                     d.Dispose,
@@ -95,7 +95,7 @@ namespace System.Linq
 
         private static IAsyncEnumerable<TSource> Catch_<TSource>(this IEnumerable<IAsyncEnumerable<TSource>> sources)
         {
-            return Create(() =>
+            return CreateEnumerable(() =>
             {
                 var se = sources.GetEnumerator();
                 var e = default(IAsyncEnumerator<TSource>);
@@ -141,7 +141,7 @@ namespace System.Linq
                     }
                 };
 
-                return Create(
+                return CreateEnumerator(
                     f,
                     () => e.Current,
                     d.Dispose,

--- a/Ix.NET/Source/System.Interactive.Async/Concatenate.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Concatenate.cs
@@ -19,46 +19,47 @@ namespace System.Linq
             if (second == null)
                 throw new ArgumentNullException(nameof(second));
 
-            return CreateEnumerable(() =>
-                          {
-                              var switched = false;
-                              var e = first.GetEnumerator();
+            return CreateEnumerable(
+                () =>
+                {
+                    var switched = false;
+                    var e = first.GetEnumerator();
 
-                              var cts = new CancellationTokenDisposable();
-                              var a = new AssignableDisposable
-                              {
-                                  Disposable = e
-                              };
-                              var d = Disposable.Create(cts, a);
+                    var cts = new CancellationTokenDisposable();
+                    var a = new AssignableDisposable
+                    {
+                        Disposable = e
+                    };
+                    var d = Disposable.Create(cts, a);
 
-                              var f = default(Func<CancellationToken, Task<bool>>);
-                              f = async ct =>
-                                  {
-                                      if (await e.MoveNext(ct)
-                                                 .ConfigureAwait(false))
-                                      {
-                                          return true;
-                                      }
-                                      if (switched)
-                                      {
-                                          return false;
-                                      }
-                                      switched = true;
+                    var f = default(Func<CancellationToken, Task<bool>>);
+                    f = async ct =>
+                        {
+                            if (await e.MoveNext(ct)
+                                       .ConfigureAwait(false))
+                            {
+                                return true;
+                            }
+                            if (switched)
+                            {
+                                return false;
+                            }
+                            switched = true;
 
-                                      e = second.GetEnumerator();
-                                      a.Disposable = e;
+                            e = second.GetEnumerator();
+                            a.Disposable = e;
 
-                                      return await f(ct)
-                                                 .ConfigureAwait(false);
-                                  };
+                            return await f(ct)
+                                       .ConfigureAwait(false);
+                        };
 
-                              return CreateEnumerator(
-                                  f,
-                                  () => e.Current,
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator(
+                        f,
+                        () => e.Current,
+                        d.Dispose,
+                        e
+                    );
+                });
         }
 
         public static IAsyncEnumerable<TSource> Concat<TSource>(this IEnumerable<IAsyncEnumerable<TSource>> sources)
@@ -79,52 +80,53 @@ namespace System.Linq
 
         private static IAsyncEnumerable<TSource> Concat_<TSource>(this IEnumerable<IAsyncEnumerable<TSource>> sources)
         {
-            return CreateEnumerable(() =>
-                          {
-                              var se = sources.GetEnumerator();
-                              var e = default(IAsyncEnumerator<TSource>);
+            return CreateEnumerable(
+                () =>
+                {
+                    var se = sources.GetEnumerator();
+                    var e = default(IAsyncEnumerator<TSource>);
 
-                              var cts = new CancellationTokenDisposable();
-                              var a = new AssignableDisposable();
-                              var d = Disposable.Create(cts, se, a);
+                    var cts = new CancellationTokenDisposable();
+                    var a = new AssignableDisposable();
+                    var d = Disposable.Create(cts, se, a);
 
-                              var f = default(Func<CancellationToken, Task<bool>>);
-                              f = async ct =>
-                                  {
-                                      if (e == null)
-                                      {
-                                          var b = false;
-                                          b = se.MoveNext();
-                                          if (b)
-                                              e = se.Current.GetEnumerator();
+                    var f = default(Func<CancellationToken, Task<bool>>);
+                    f = async ct =>
+                        {
+                            if (e == null)
+                            {
+                                var b = false;
+                                b = se.MoveNext();
+                                if (b)
+                                    e = se.Current.GetEnumerator();
 
-                                          if (!b)
-                                          {
-                                              return false;
-                                          }
+                                if (!b)
+                                {
+                                    return false;
+                                }
 
-                                          a.Disposable = e;
-                                      }
+                                a.Disposable = e;
+                            }
 
-                                      if (await e.MoveNext(ct)
-                                                 .ConfigureAwait(false))
-                                      {
-                                          return true;
-                                      }
-                                      e.Dispose();
-                                      e = null;
+                            if (await e.MoveNext(ct)
+                                       .ConfigureAwait(false))
+                            {
+                                return true;
+                            }
+                            e.Dispose();
+                            e = null;
 
-                                      return await f(ct)
-                                                 .ConfigureAwait(false);
-                                  };
+                            return await f(ct)
+                                       .ConfigureAwait(false);
+                        };
 
-                              return CreateEnumerator(
-                                  f,
-                                  () => e.Current,
-                                  d.Dispose,
-                                  a
-                              );
-                          });
+                    return CreateEnumerator(
+                        f,
+                        () => e.Current,
+                        d.Dispose,
+                        a
+                    );
+                });
         }
     }
 }

--- a/Ix.NET/Source/System.Interactive.Async/Concatenate.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Concatenate.cs
@@ -19,7 +19,7 @@ namespace System.Linq
             if (second == null)
                 throw new ArgumentNullException(nameof(second));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var switched = false;
                               var e = first.GetEnumerator();
@@ -52,7 +52,7 @@ namespace System.Linq
                                                  .ConfigureAwait(false);
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   f,
                                   () => e.Current,
                                   d.Dispose,
@@ -79,7 +79,7 @@ namespace System.Linq
 
         private static IAsyncEnumerable<TSource> Concat_<TSource>(this IEnumerable<IAsyncEnumerable<TSource>> sources)
         {
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var se = sources.GetEnumerator();
                               var e = default(IAsyncEnumerator<TSource>);
@@ -118,7 +118,7 @@ namespace System.Linq
                                                  .ConfigureAwait(false);
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   f,
                                   () => e.Current,
                                   d.Dispose,

--- a/Ix.NET/Source/System.Interactive.Async/Create.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Create.cs
@@ -25,27 +25,28 @@ namespace System.Linq
         private static IAsyncEnumerator<T> CreateEnumerator<T>(Func<CancellationToken, Task<bool>> moveNext, Func<T> current,
                                                                Action dispose, IDisposable enumerator)
         {
-            return CreateEnumerator(async ct =>
-                                    {
-                                        using (ct.Register(dispose))
-                                        {
-                                            try
-                                            {
-                                                var result = await moveNext(ct)
-                                                                 .ConfigureAwait(false);
-                                                if (!result)
-                                                {
-                                                    enumerator?.Dispose();
-                                                }
-                                                return result;
-                                            }
-                                            catch
-                                            {
-                                                enumerator?.Dispose();
-                                                throw;
-                                            }
-                                        }
-                                    }, current, dispose);
+            return CreateEnumerator(
+                async ct =>
+                {
+                    using (ct.Register(dispose))
+                    {
+                        try
+                        {
+                            var result = await moveNext(ct)
+                                             .ConfigureAwait(false);
+                            if (!result)
+                            {
+                                enumerator?.Dispose();
+                            }
+                            return result;
+                        }
+                        catch
+                        {
+                            enumerator?.Dispose();
+                            throw;
+                        }
+                    }
+                }, current, dispose);
         }
 
         private static IAsyncEnumerator<T> CreateEnumerator<T>(Func<CancellationToken, TaskCompletionSource<bool>, Task<bool>> moveNext, Func<T> current, Action dispose)
@@ -56,11 +57,12 @@ namespace System.Linq
                 {
                     var tcs = new TaskCompletionSource<bool>();
 
-                    var stop = new Action(() =>
-                                          {
-                                              self.Dispose();
-                                              tcs.TrySetCanceled();
-                                          });
+                    var stop = new Action(
+                        () =>
+                        {
+                            self.Dispose();
+                            tcs.TrySetCanceled();
+                        });
 
                     using (ct.Register(stop))
                     {
@@ -111,10 +113,7 @@ namespace System.Linq
                 return _moveNext(cancellationToken);
             }
 
-            public T Current
-            {
-                get { return _current(); }
-            }
+            public T Current => _current();
 
             public void Dispose()
             {

--- a/Ix.NET/Source/System.Interactive.Async/DefaultIfEmpty.cs
+++ b/Ix.NET/Source/System.Interactive.Async/DefaultIfEmpty.cs
@@ -1,6 +1,6 @@
-﻿// // Licensed to the .NET Foundation under one or more agreements.
-// // The .NET Foundation licenses this file to you under the Apache 2.0 License.
-// // See the LICENSE file in the project root for more information. 
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information. 
 
 using System;
 using System.Collections.Generic;
@@ -17,44 +17,45 @@ namespace System.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return CreateEnumerable(() =>
-                          {
-                              var done = false;
-                              var hasElements = false;
-                              var e = source.GetEnumerator();
-                              var current = default(TSource);
+            return CreateEnumerable(
+                () =>
+                {
+                    var done = false;
+                    var hasElements = false;
+                    var e = source.GetEnumerator();
+                    var current = default(TSource);
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, e);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, e);
 
-                              var f = default(Func<CancellationToken, Task<bool>>);
-                              f = async ct =>
-                                  {
-                                      if (done)
-                                          return false;
-                                      if (await e.MoveNext(ct)
-                                                 .ConfigureAwait(false))
-                                      {
-                                          hasElements = true;
-                                          current = e.Current;
-                                          return true;
-                                      }
-                                      done = true;
-                                      if (!hasElements)
-                                      {
-                                          current = defaultValue;
-                                          return true;
-                                      }
-                                      return false;
-                                  };
+                    var f = default(Func<CancellationToken, Task<bool>>);
+                    f = async ct =>
+                        {
+                            if (done)
+                                return false;
+                            if (await e.MoveNext(ct)
+                                       .ConfigureAwait(false))
+                            {
+                                hasElements = true;
+                                current = e.Current;
+                                return true;
+                            }
+                            done = true;
+                            if (!hasElements)
+                            {
+                                current = defaultValue;
+                                return true;
+                            }
+                            return false;
+                        };
 
-                              return CreateEnumerator(
-                                  f,
-                                  () => current,
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator(
+                        f,
+                        () => current,
+                        d.Dispose,
+                        e
+                    );
+                });
         }
 
         public static IAsyncEnumerable<TSource> DefaultIfEmpty<TSource>(this IAsyncEnumerable<TSource> source)

--- a/Ix.NET/Source/System.Interactive.Async/DefaultIfEmpty.cs
+++ b/Ix.NET/Source/System.Interactive.Async/DefaultIfEmpty.cs
@@ -17,7 +17,7 @@ namespace System.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var done = false;
                               var hasElements = false;
@@ -48,7 +48,7 @@ namespace System.Linq
                                       return false;
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   f,
                                   () => current,
                                   d.Dispose,

--- a/Ix.NET/Source/System.Interactive.Async/Defer.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Defer.cs
@@ -16,7 +16,7 @@ namespace System.Linq
             if (factory == null)
                 throw new ArgumentNullException(nameof(factory));
 
-            return Create(() => factory()
+            return CreateEnumerable(() => factory()
                               .GetEnumerator());
         }
     }

--- a/Ix.NET/Source/System.Interactive.Async/Defer.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Defer.cs
@@ -16,8 +16,9 @@ namespace System.Linq
             if (factory == null)
                 throw new ArgumentNullException(nameof(factory));
 
-            return CreateEnumerable(() => factory()
-                              .GetEnumerator());
+            return CreateEnumerable(
+                () => factory()
+                    .GetEnumerator());
         }
     }
 }

--- a/Ix.NET/Source/System.Interactive.Async/Distinct.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Distinct.cs
@@ -102,7 +102,7 @@ namespace System.Linq
 
         private static IAsyncEnumerable<TSource> DistinctUntilChanged_<TSource, TKey>(this IAsyncEnumerable<TSource> source, Func<TSource, TKey> keySelector, IEqualityComparer<TKey> comparer)
         {
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
 
@@ -144,7 +144,7 @@ namespace System.Linq
                                       return false;
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   f,
                                   () => current,
                                   d.Dispose,

--- a/Ix.NET/Source/System.Interactive.Async/Do.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Do.cs
@@ -72,51 +72,52 @@ namespace System.Linq
 
         private static IAsyncEnumerable<TSource> DoHelper<TSource>(this IAsyncEnumerable<TSource> source, Action<TSource> onNext, Action<Exception> onError, Action onCompleted)
         {
-            return CreateEnumerable(() =>
-                          {
-                              var e = source.GetEnumerator();
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = source.GetEnumerator();
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, e);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, e);
 
-                              var current = default(TSource);
+                    var current = default(TSource);
 
-                              var f = default(Func<CancellationToken, Task<bool>>);
-                              f = async ct =>
-                                  {
-                                      try
-                                      {
-                                          var result = await e.MoveNext(ct)
-                                                              .ConfigureAwait(false);
-                                          if (!result)
-                                          {
-                                              onCompleted();
-                                          }
-                                          else
-                                          {
-                                              current = e.Current;
-                                              onNext(current);
-                                          }
-                                          return result;
-                                      }
-                                      catch (OperationCanceledException)
-                                      {
-                                          throw;
-                                      }
-                                      catch (Exception ex)
-                                      {
-                                          onError(ex);
-                                          throw;
-                                      }
-                                  };
+                    var f = default(Func<CancellationToken, Task<bool>>);
+                    f = async ct =>
+                        {
+                            try
+                            {
+                                var result = await e.MoveNext(ct)
+                                                    .ConfigureAwait(false);
+                                if (!result)
+                                {
+                                    onCompleted();
+                                }
+                                else
+                                {
+                                    current = e.Current;
+                                    onNext(current);
+                                }
+                                return result;
+                            }
+                            catch (OperationCanceledException)
+                            {
+                                throw;
+                            }
+                            catch (Exception ex)
+                            {
+                                onError(ex);
+                                throw;
+                            }
+                        };
 
-                              return CreateEnumerator(
-                                  f,
-                                  () => current,
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator(
+                        f,
+                        () => current,
+                        d.Dispose,
+                        e
+                    );
+                });
         }
     }
 }

--- a/Ix.NET/Source/System.Interactive.Async/Do.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Do.cs
@@ -72,7 +72,7 @@ namespace System.Linq
 
         private static IAsyncEnumerable<TSource> DoHelper<TSource>(this IAsyncEnumerable<TSource> source, Action<TSource> onNext, Action<Exception> onError, Action onCompleted)
         {
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
 
@@ -110,7 +110,7 @@ namespace System.Linq
                                       }
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   f,
                                   () => current,
                                   d.Dispose,

--- a/Ix.NET/Source/System.Interactive.Async/Except.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Except.cs
@@ -31,7 +31,7 @@ namespace System.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = first.GetEnumerator();
 
@@ -57,7 +57,7 @@ namespace System.Linq
                                       return false;
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   f,
                                   () => e.Current,
                                   d.Dispose,

--- a/Ix.NET/Source/System.Interactive.Async/Expand.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Expand.cs
@@ -19,7 +19,7 @@ namespace System.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = default(IAsyncEnumerator<TSource>);
 
@@ -64,7 +64,7 @@ namespace System.Linq
                                                  .ConfigureAwait(false);
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   f,
                                   () => current,
                                   d.Dispose,

--- a/Ix.NET/Source/System.Interactive.Async/Expand.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Expand.cs
@@ -19,58 +19,59 @@ namespace System.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = default(IAsyncEnumerator<TSource>);
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = default(IAsyncEnumerator<TSource>);
 
-                              var cts = new CancellationTokenDisposable();
-                              var a = new AssignableDisposable();
-                              var d = Disposable.Create(cts, a);
+                    var cts = new CancellationTokenDisposable();
+                    var a = new AssignableDisposable();
+                    var d = Disposable.Create(cts, a);
 
-                              var queue = new Queue<IAsyncEnumerable<TSource>>();
-                              queue.Enqueue(source);
+                    var queue = new Queue<IAsyncEnumerable<TSource>>();
+                    queue.Enqueue(source);
 
-                              var current = default(TSource);
+                    var current = default(TSource);
 
-                              var f = default(Func<CancellationToken, Task<bool>>);
-                              f = async ct =>
-                                  {
-                                      if (e == null)
-                                      {
-                                          if (queue.Count > 0)
-                                          {
-                                              var src = queue.Dequeue();
+                    var f = default(Func<CancellationToken, Task<bool>>);
+                    f = async ct =>
+                        {
+                            if (e == null)
+                            {
+                                if (queue.Count > 0)
+                                {
+                                    var src = queue.Dequeue();
 
-                                              e = src.GetEnumerator();
+                                    e = src.GetEnumerator();
 
-                                              a.Disposable = e;
-                                              return await f(ct)
-                                                         .ConfigureAwait(false);
-                                          }
-                                          return false;
-                                      }
-                                      if (await e.MoveNext(ct)
-                                                 .ConfigureAwait(false))
-                                      {
-                                          var item = e.Current;
-                                          var next = selector(item);
+                                    a.Disposable = e;
+                                    return await f(ct)
+                                               .ConfigureAwait(false);
+                                }
+                                return false;
+                            }
+                            if (await e.MoveNext(ct)
+                                       .ConfigureAwait(false))
+                            {
+                                var item = e.Current;
+                                var next = selector(item);
 
-                                          queue.Enqueue(next);
-                                          current = item;
-                                          return true;
-                                      }
-                                      e = null;
-                                      return await f(ct)
-                                                 .ConfigureAwait(false);
-                                  };
+                                queue.Enqueue(next);
+                                current = item;
+                                return true;
+                            }
+                            e = null;
+                            return await f(ct)
+                                       .ConfigureAwait(false);
+                        };
 
-                              return CreateEnumerator(
-                                  f,
-                                  () => current,
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator(
+                        f,
+                        () => current,
+                        d.Dispose,
+                        e
+                    );
+                });
         }
     }
 }

--- a/Ix.NET/Source/System.Interactive.Async/Finally.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Finally.cs
@@ -18,21 +18,22 @@ namespace System.Linq
             if (finallyAction == null)
                 throw new ArgumentNullException(nameof(finallyAction));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = source.GetEnumerator();
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = source.GetEnumerator();
 
-                              var cts = new CancellationTokenDisposable();
-                              var r = new Disposable(finallyAction);
-                              var d = Disposable.Create(cts, e, r);
+                    var cts = new CancellationTokenDisposable();
+                    var r = new Disposable(finallyAction);
+                    var d = Disposable.Create(cts, e, r);
 
-                              return CreateEnumerator(
-                                  ct => e.MoveNext(ct),
-                                  () => e.Current,
-                                  d.Dispose,
-                                  r
-                              );
-                          });
+                    return CreateEnumerator(
+                        ct => e.MoveNext(ct),
+                        () => e.Current,
+                        d.Dispose,
+                        r
+                    );
+                });
         }
     }
 }

--- a/Ix.NET/Source/System.Interactive.Async/Finally.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Finally.cs
@@ -18,7 +18,7 @@ namespace System.Linq
             if (finallyAction == null)
                 throw new ArgumentNullException(nameof(finallyAction));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
 
@@ -26,7 +26,7 @@ namespace System.Linq
                               var r = new Disposable(finallyAction);
                               var d = Disposable.Create(cts, e, r);
 
-                              return Create(
+                              return CreateEnumerator(
                                   ct => e.MoveNext(ct),
                                   () => e.Current,
                                   d.Dispose,

--- a/Ix.NET/Source/System.Interactive.Async/Generate.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Generate.cs
@@ -20,43 +20,44 @@ namespace System.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return CreateEnumerable(() =>
-                          {
-                              var i = initialState;
-                              var started = false;
-                              var current = default(TResult);
+            return CreateEnumerable(
+                () =>
+                {
+                    var i = initialState;
+                    var started = false;
+                    var current = default(TResult);
 
-                              return CreateEnumerator(
-                                  ct =>
-                                  {
-                                      var b = false;
-                                      try
-                                      {
-                                          if (started)
-                                              i = iterate(i);
+                    return CreateEnumerator(
+                        ct =>
+                        {
+                            var b = false;
+                            try
+                            {
+                                if (started)
+                                    i = iterate(i);
 
-                                          b = condition(i);
+                                b = condition(i);
 
-                                          if (b)
-                                              current = resultSelector(i);
-                                      }
-                                      catch (Exception ex)
-                                      {
-                                          return TaskExt.Throw<bool>(ex);
-                                      }
+                                if (b)
+                                    current = resultSelector(i);
+                            }
+                            catch (Exception ex)
+                            {
+                                return TaskExt.Throw<bool>(ex);
+                            }
 
-                                      if (!b)
-                                          return TaskExt.False;
+                            if (!b)
+                                return TaskExt.False;
 
-                                      if (!started)
-                                          started = true;
+                            if (!started)
+                                started = true;
 
-                                      return TaskExt.True;
-                                  },
-                                  () => current,
-                                  () => { }
-                              );
-                          });
+                            return TaskExt.True;
+                        },
+                        () => current,
+                        () => { }
+                    );
+                });
         }
     }
 }

--- a/Ix.NET/Source/System.Interactive.Async/Generate.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Generate.cs
@@ -20,13 +20,13 @@ namespace System.Linq
             if (resultSelector == null)
                 throw new ArgumentNullException(nameof(resultSelector));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var i = initialState;
                               var started = false;
                               var current = default(TResult);
 
-                              return Create(
+                              return CreateEnumerator(
                                   ct =>
                                   {
                                       var b = false;

--- a/Ix.NET/Source/System.Interactive.Async/Grouping.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Grouping.cs
@@ -25,7 +25,7 @@ namespace System.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var gate = new object();
 
@@ -139,7 +139,7 @@ namespace System.Linq
                                                  .ConfigureAwait(false);
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   f,
                                   () => current,
                                   d.Dispose,
@@ -306,7 +306,7 @@ namespace System.Linq
                         return false;
                     };
 
-                return Create(
+                return CreateEnumerator(
                     ct =>
                     {
                         ++index;

--- a/Ix.NET/Source/System.Interactive.Async/IgnoreElements.cs
+++ b/Ix.NET/Source/System.Interactive.Async/IgnoreElements.cs
@@ -17,7 +17,7 @@ namespace System.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
 
@@ -37,7 +37,7 @@ namespace System.Linq
                                                  .ConfigureAwait(false);
                                   };
 
-                              return Create<TSource>(
+                              return CreateEnumerator<TSource>(
                                   f,
                                   () => { throw new InvalidOperationException(); },
                                   d.Dispose,

--- a/Ix.NET/Source/System.Interactive.Async/IgnoreElements.cs
+++ b/Ix.NET/Source/System.Interactive.Async/IgnoreElements.cs
@@ -17,33 +17,34 @@ namespace System.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = source.GetEnumerator();
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = source.GetEnumerator();
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, e);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, e);
 
-                              var f = default(Func<CancellationToken, Task<bool>>);
-                              f = async ct =>
-                                  {
-                                      if (!await e.MoveNext(ct)
-                                                  .ConfigureAwait(false))
-                                      {
-                                          return false;
-                                      }
+                    var f = default(Func<CancellationToken, Task<bool>>);
+                    f = async ct =>
+                        {
+                            if (!await e.MoveNext(ct)
+                                        .ConfigureAwait(false))
+                            {
+                                return false;
+                            }
 
-                                      return await f(ct)
-                                                 .ConfigureAwait(false);
-                                  };
+                            return await f(ct)
+                                       .ConfigureAwait(false);
+                        };
 
-                              return CreateEnumerator<TSource>(
-                                  f,
-                                  () => { throw new InvalidOperationException(); },
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator<TSource>(
+                        f,
+                        () => { throw new InvalidOperationException(); },
+                        d.Dispose,
+                        e
+                    );
+                });
         }
     }
 }

--- a/Ix.NET/Source/System.Interactive.Async/Intersect.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Intersect.cs
@@ -21,7 +21,7 @@ namespace System.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = first.GetEnumerator();
 
@@ -54,7 +54,7 @@ namespace System.Linq
                                       return false;
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   f,
                                   () => e.Current,
                                   d.Dispose,

--- a/Ix.NET/Source/System.Interactive.Async/Intersect.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Intersect.cs
@@ -21,46 +21,47 @@ namespace System.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = first.GetEnumerator();
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = first.GetEnumerator();
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, e);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, e);
 
-                              var mapTask = default(Task<Dictionary<TSource, TSource>>);
-                              var getMapTask = new Func<CancellationToken, Task<Dictionary<TSource, TSource>>>(
-                                  ct =>
-                                  {
-                                      if (mapTask == null)
-                                          mapTask = second.ToDictionary(x => x, comparer, ct);
-                                      return mapTask;
-                                  });
+                    var mapTask = default(Task<Dictionary<TSource, TSource>>);
+                    var getMapTask = new Func<CancellationToken, Task<Dictionary<TSource, TSource>>>(
+                        ct =>
+                        {
+                            if (mapTask == null)
+                                mapTask = second.ToDictionary(x => x, comparer, ct);
+                            return mapTask;
+                        });
 
-                              var f = default(Func<CancellationToken, Task<bool>>);
-                              f = async ct =>
-                                  {
-                                      if (await e.MoveNext(ct)
-                                                 .Zip(getMapTask(ct), (b, _) => b)
-                                                 .ConfigureAwait(false))
-                                      {
-                                          // Note: Result here is safe because the task
-                                          // was completed in the Zip() call above
-                                          if (mapTask.Result.ContainsKey(e.Current))
-                                              return true;
-                                          return await f(ct)
-                                                     .ConfigureAwait(false);
-                                      }
-                                      return false;
-                                  };
+                    var f = default(Func<CancellationToken, Task<bool>>);
+                    f = async ct =>
+                        {
+                            if (await e.MoveNext(ct)
+                                       .Zip(getMapTask(ct), (b, _) => b)
+                                       .ConfigureAwait(false))
+                            {
+                                // Note: Result here is safe because the task
+                                // was completed in the Zip() call above
+                                if (mapTask.Result.ContainsKey(e.Current))
+                                    return true;
+                                return await f(ct)
+                                           .ConfigureAwait(false);
+                            }
+                            return false;
+                        };
 
-                              return CreateEnumerator(
-                                  f,
-                                  () => e.Current,
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator(
+                        f,
+                        () => e.Current,
+                        d.Dispose,
+                        e
+                    );
+                });
         }
 
 

--- a/Ix.NET/Source/System.Interactive.Async/Join.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Join.cs
@@ -27,7 +27,7 @@ namespace System.Linq
             if (comparer == null)
                 throw new ArgumentNullException(nameof(comparer));
 
-            return Create(
+            return CreateEnumerable(
                 () =>
                 {
                     var oe = outer.GetEnumerator();
@@ -147,7 +147,7 @@ namespace System.Linq
                                        .ConfigureAwait(false);
                         };
 
-                    return Create(
+                    return CreateEnumerator(
                         f,
                         () => current,
                         d.Dispose,

--- a/Ix.NET/Source/System.Interactive.Async/OnErrorResumeNext.cs
+++ b/Ix.NET/Source/System.Interactive.Async/OnErrorResumeNext.cs
@@ -40,7 +40,7 @@ namespace System.Linq
 
         private static IAsyncEnumerable<TSource> OnErrorResumeNext_<TSource>(IEnumerable<IAsyncEnumerable<TSource>> sources)
         {
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var se = sources.GetEnumerator();
                               var e = default(IAsyncEnumerator<TSource>);
@@ -85,7 +85,7 @@ namespace System.Linq
                                                  .ConfigureAwait(false);
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   f,
                                   () => e.Current,
                                   d.Dispose,

--- a/Ix.NET/Source/System.Interactive.Async/OrderBy.cs
+++ b/Ix.NET/Source/System.Interactive.Async/OrderBy.cs
@@ -22,11 +22,11 @@ namespace System.Linq
                 throw new ArgumentNullException(nameof(comparer));
 
             return new OrderedAsyncEnumerable<TSource, TKey>(
-                Create(() =>
+                CreateEnumerable(() =>
                        {
                            var current = default(IEnumerable<TSource>);
 
-                           return Create(
+                           return CreateEnumerator(
                                async ct =>
                                {
                                    if (current == null)
@@ -152,7 +152,7 @@ namespace System.Linq
 
             private IAsyncEnumerable<IEnumerable<T>> Classes()
             {
-                return Create(() =>
+                return CreateEnumerable(() =>
                               {
                                   var e = equivalenceClasses.GetEnumerator();
                                   var list = new List<IEnumerable<T>>();
@@ -182,7 +182,7 @@ namespace System.Linq
                                           return e1.MoveNext();
                                       };
 
-                                  return Create(
+                                  return CreateEnumerator(
                                       async ct =>
                                       {
                                           if (e1 != null)

--- a/Ix.NET/Source/System.Interactive.Async/Repeat.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Repeat.cs
@@ -23,16 +23,16 @@ namespace System.Linq
 
         public static IAsyncEnumerable<TResult> Repeat<TResult>(TResult element)
         {
-            return CreateEnumerable(() =>
-                          {
-                              return CreateEnumerator(
-                                  ct => TaskExt.True,
-                                  () => element,
-                                  () => { }
-                              );
-                          });
+            return CreateEnumerable(
+                () =>
+                {
+                    return CreateEnumerator(
+                        ct => TaskExt.True,
+                        () => element,
+                        () => { }
+                    );
+                });
         }
-
 
         public static IAsyncEnumerable<TSource> Repeat<TSource>(this IAsyncEnumerable<TSource> source, int count)
         {
@@ -41,49 +41,50 @@ namespace System.Linq
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = default(IAsyncEnumerator<TSource>);
-                              var a = new AssignableDisposable();
-                              var n = count;
-                              var current = default(TSource);
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = default(IAsyncEnumerator<TSource>);
+                    var a = new AssignableDisposable();
+                    var n = count;
+                    var current = default(TSource);
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, a);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, a);
 
-                              var f = default(Func<CancellationToken, Task<bool>>);
-                              f = async ct =>
-                                  {
-                                      if (e == null)
-                                      {
-                                          if (n-- == 0)
-                                          {
-                                              return false;
-                                          }
+                    var f = default(Func<CancellationToken, Task<bool>>);
+                    f = async ct =>
+                        {
+                            if (e == null)
+                            {
+                                if (n-- == 0)
+                                {
+                                    return false;
+                                }
 
-                                          e = source.GetEnumerator();
+                                e = source.GetEnumerator();
 
-                                          a.Disposable = e;
-                                      }
+                                a.Disposable = e;
+                            }
 
-                                      if (await e.MoveNext(ct)
-                                                 .ConfigureAwait(false))
-                                      {
-                                          current = e.Current;
-                                          return true;
-                                      }
-                                      e = null;
-                                      return await f(ct)
-                                                 .ConfigureAwait(false);
-                                  };
+                            if (await e.MoveNext(ct)
+                                       .ConfigureAwait(false))
+                            {
+                                current = e.Current;
+                                return true;
+                            }
+                            e = null;
+                            return await f(ct)
+                                       .ConfigureAwait(false);
+                        };
 
-                              return CreateEnumerator(
-                                  f,
-                                  () => current,
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator(
+                        f,
+                        () => current,
+                        d.Dispose,
+                        e
+                    );
+                });
         }
 
         public static IAsyncEnumerable<TSource> Repeat<TSource>(this IAsyncEnumerable<TSource> source)
@@ -91,43 +92,44 @@ namespace System.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = default(IAsyncEnumerator<TSource>);
-                              var a = new AssignableDisposable();
-                              var current = default(TSource);
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = default(IAsyncEnumerator<TSource>);
+                    var a = new AssignableDisposable();
+                    var current = default(TSource);
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, a);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, a);
 
-                              var f = default(Func<CancellationToken, Task<bool>>);
-                              f = async ct =>
-                                  {
-                                      if (e == null)
-                                      {
-                                          e = source.GetEnumerator();
+                    var f = default(Func<CancellationToken, Task<bool>>);
+                    f = async ct =>
+                        {
+                            if (e == null)
+                            {
+                                e = source.GetEnumerator();
 
-                                          a.Disposable = e;
-                                      }
+                                a.Disposable = e;
+                            }
 
-                                      if (await e.MoveNext(ct)
-                                                 .ConfigureAwait(false))
-                                      {
-                                          current = e.Current;
-                                          return true;
-                                      }
-                                      e = null;
-                                      return await f(ct)
-                                                 .ConfigureAwait(false);
-                                  };
+                            if (await e.MoveNext(ct)
+                                       .ConfigureAwait(false))
+                            {
+                                current = e.Current;
+                                return true;
+                            }
+                            e = null;
+                            return await f(ct)
+                                       .ConfigureAwait(false);
+                        };
 
-                              return CreateEnumerator(
-                                  f,
-                                  () => current,
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator(
+                        f,
+                        () => current,
+                        d.Dispose,
+                        e
+                    );
+                });
         }
     }
 }

--- a/Ix.NET/Source/System.Interactive.Async/Repeat.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Repeat.cs
@@ -23,9 +23,9 @@ namespace System.Linq
 
         public static IAsyncEnumerable<TResult> Repeat<TResult>(TResult element)
         {
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
-                              return Create(
+                              return CreateEnumerator(
                                   ct => TaskExt.True,
                                   () => element,
                                   () => { }
@@ -41,7 +41,7 @@ namespace System.Linq
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = default(IAsyncEnumerator<TSource>);
                               var a = new AssignableDisposable();
@@ -77,7 +77,7 @@ namespace System.Linq
                                                  .ConfigureAwait(false);
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   f,
                                   () => current,
                                   d.Dispose,
@@ -91,7 +91,7 @@ namespace System.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = default(IAsyncEnumerator<TSource>);
                               var a = new AssignableDisposable();
@@ -121,7 +121,7 @@ namespace System.Linq
                                                  .ConfigureAwait(false);
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   f,
                                   () => current,
                                   d.Dispose,

--- a/Ix.NET/Source/System.Interactive.Async/Reverse.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Reverse.cs
@@ -16,7 +16,7 @@ namespace System.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
                               var stack = default(Stack<TSource>);
@@ -24,12 +24,12 @@ namespace System.Linq
                               var cts = new CancellationTokenDisposable();
                               var d = Disposable.Create(cts, e);
 
-                              return Create(
+                              return CreateEnumerator(
                                   async ct =>
                                   {
                                       if (stack == null)
                                       {
-                                          stack = await Create(() => e)
+                                          stack = await CreateEnumerable(() => e)
                                                       .Aggregate(new Stack<TSource>(), (s, x) =>
                                                                                        {
                                                                                            s.Push(x);

--- a/Ix.NET/Source/System.Interactive.Async/Reverse.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Reverse.cs
@@ -16,36 +16,38 @@ namespace System.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = source.GetEnumerator();
-                              var stack = default(Stack<TSource>);
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = source.GetEnumerator();
+                    var stack = default(Stack<TSource>);
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, e);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, e);
 
-                              return CreateEnumerator(
-                                  async ct =>
-                                  {
-                                      if (stack == null)
-                                      {
-                                          stack = await CreateEnumerable(() => e)
-                                                      .Aggregate(new Stack<TSource>(), (s, x) =>
-                                                                                       {
-                                                                                           s.Push(x);
-                                                                                           return s;
-                                                                                       }, cts.Token)
-                                                      .ConfigureAwait(false);
-                                          return stack.Count > 0;
-                                      }
-                                      stack.Pop();
-                                      return stack.Count > 0;
-                                  },
-                                  () => stack.Peek(),
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator(
+                        async ct =>
+                        {
+                            if (stack == null)
+                            {
+                                stack = await CreateEnumerable(
+                                                () => e)
+                                            .Aggregate(new Stack<TSource>(), (s, x) =>
+                                                                             {
+                                                                                 s.Push(x);
+                                                                                 return s;
+                                                                             }, cts.Token)
+                                            .ConfigureAwait(false);
+                                return stack.Count > 0;
+                            }
+                            stack.Pop();
+                            return stack.Count > 0;
+                        },
+                        () => stack.Peek(),
+                        d.Dispose,
+                        e
+                    );
+                });
         }
     }
 }

--- a/Ix.NET/Source/System.Interactive.Async/Scan.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Scan.cs
@@ -19,39 +19,40 @@ namespace System.Linq
             if (accumulator == null)
                 throw new ArgumentNullException(nameof(accumulator));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = source.GetEnumerator();
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = source.GetEnumerator();
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, e);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, e);
 
-                              var acc = seed;
-                              var current = default(TAccumulate);
+                    var acc = seed;
+                    var current = default(TAccumulate);
 
-                              var f = default(Func<CancellationToken, Task<bool>>);
-                              f = async ct =>
-                                  {
-                                      if (!await e.MoveNext(ct)
-                                                  .ConfigureAwait(false))
-                                      {
-                                          return false;
-                                      }
+                    var f = default(Func<CancellationToken, Task<bool>>);
+                    f = async ct =>
+                        {
+                            if (!await e.MoveNext(ct)
+                                        .ConfigureAwait(false))
+                            {
+                                return false;
+                            }
 
-                                      var item = e.Current;
-                                      acc = accumulator(acc, item);
+                            var item = e.Current;
+                            acc = accumulator(acc, item);
 
-                                      current = acc;
-                                      return true;
-                                  };
+                            current = acc;
+                            return true;
+                        };
 
-                              return CreateEnumerator(
-                                  f,
-                                  () => current,
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator(
+                        f,
+                        () => current,
+                        d.Dispose,
+                        e
+                    );
+                });
         }
 
         public static IAsyncEnumerable<TSource> Scan<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, TSource, TSource> accumulator)
@@ -61,49 +62,50 @@ namespace System.Linq
             if (accumulator == null)
                 throw new ArgumentNullException(nameof(accumulator));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = source.GetEnumerator();
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = source.GetEnumerator();
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, e);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, e);
 
-                              var hasSeed = false;
-                              var acc = default(TSource);
-                              var current = default(TSource);
+                    var hasSeed = false;
+                    var acc = default(TSource);
+                    var current = default(TSource);
 
-                              var f = default(Func<CancellationToken, Task<bool>>);
-                              f = async ct =>
-                                  {
-                                      if (!await e.MoveNext(ct)
-                                                  .ConfigureAwait(false))
-                                      {
-                                          return false;
-                                      }
+                    var f = default(Func<CancellationToken, Task<bool>>);
+                    f = async ct =>
+                        {
+                            if (!await e.MoveNext(ct)
+                                        .ConfigureAwait(false))
+                            {
+                                return false;
+                            }
 
-                                      var item = e.Current;
+                            var item = e.Current;
 
-                                      if (!hasSeed)
-                                      {
-                                          hasSeed = true;
-                                          acc = item;
-                                          return await f(ct)
-                                                     .ConfigureAwait(false);
-                                      }
+                            if (!hasSeed)
+                            {
+                                hasSeed = true;
+                                acc = item;
+                                return await f(ct)
+                                           .ConfigureAwait(false);
+                            }
 
-                                      acc = accumulator(acc, item);
+                            acc = accumulator(acc, item);
 
-                                      current = acc;
-                                      return true;
-                                  };
+                            current = acc;
+                            return true;
+                        };
 
-                              return CreateEnumerator(
-                                  f,
-                                  () => current,
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator(
+                        f,
+                        () => current,
+                        d.Dispose,
+                        e
+                    );
+                });
         }
     }
 }

--- a/Ix.NET/Source/System.Interactive.Async/Scan.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Scan.cs
@@ -19,7 +19,7 @@ namespace System.Linq
             if (accumulator == null)
                 throw new ArgumentNullException(nameof(accumulator));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
 
@@ -45,7 +45,7 @@ namespace System.Linq
                                       return true;
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   f,
                                   () => current,
                                   d.Dispose,
@@ -61,7 +61,7 @@ namespace System.Linq
             if (accumulator == null)
                 throw new ArgumentNullException(nameof(accumulator));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
 
@@ -97,7 +97,7 @@ namespace System.Linq
                                       return true;
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   f,
                                   () => current,
                                   d.Dispose,

--- a/Ix.NET/Source/System.Interactive.Async/Select.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Select.cs
@@ -18,7 +18,7 @@ namespace System.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
                               var current = default(TResult);
@@ -26,7 +26,7 @@ namespace System.Linq
                               var cts = new CancellationTokenDisposable();
                               var d = Disposable.Create(cts, e);
 
-                              return Create(
+                              return CreateEnumerator(
                                   async ct =>
                                   {
                                       if (await e.MoveNext(cts.Token)
@@ -51,7 +51,7 @@ namespace System.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
                               var current = default(TResult);
@@ -60,7 +60,7 @@ namespace System.Linq
                               var cts = new CancellationTokenDisposable();
                               var d = Disposable.Create(cts, e);
 
-                              return Create(
+                              return CreateEnumerator(
                                   async ct =>
                                   {
                                       if (await e.MoveNext(cts.Token)

--- a/Ix.NET/Source/System.Interactive.Async/Select.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Select.cs
@@ -18,30 +18,31 @@ namespace System.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = source.GetEnumerator();
-                              var current = default(TResult);
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = source.GetEnumerator();
+                    var current = default(TResult);
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, e);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, e);
 
-                              return CreateEnumerator(
-                                  async ct =>
-                                  {
-                                      if (await e.MoveNext(cts.Token)
-                                                 .ConfigureAwait(false))
-                                      {
-                                          current = selector(e.Current);
-                                          return true;
-                                      }
-                                      return false;
-                                  },
-                                  () => current,
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator(
+                        async ct =>
+                        {
+                            if (await e.MoveNext(cts.Token)
+                                       .ConfigureAwait(false))
+                            {
+                                current = selector(e.Current);
+                                return true;
+                            }
+                            return false;
+                        },
+                        () => current,
+                        d.Dispose,
+                        e
+                    );
+                });
         }
 
         public static IAsyncEnumerable<TResult> Select<TSource, TResult>(this IAsyncEnumerable<TSource> source, Func<TSource, int, TResult> selector)
@@ -51,31 +52,32 @@ namespace System.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = source.GetEnumerator();
-                              var current = default(TResult);
-                              var index = 0;
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = source.GetEnumerator();
+                    var current = default(TResult);
+                    var index = 0;
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, e);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, e);
 
-                              return CreateEnumerator(
-                                  async ct =>
-                                  {
-                                      if (await e.MoveNext(cts.Token)
-                                                 .ConfigureAwait(false))
-                                      {
-                                          current = selector(e.Current, checked(index++));
-                                          return true;
-                                      }
-                                      return false;
-                                  },
-                                  () => current,
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator(
+                        async ct =>
+                        {
+                            if (await e.MoveNext(cts.Token)
+                                       .ConfigureAwait(false))
+                            {
+                                current = selector(e.Current, checked(index++));
+                                return true;
+                            }
+                            return false;
+                        },
+                        () => current,
+                        d.Dispose,
+                        e
+                    );
+                });
         }
     }
 }

--- a/Ix.NET/Source/System.Interactive.Async/SelectMany.cs
+++ b/Ix.NET/Source/System.Interactive.Async/SelectMany.cs
@@ -30,7 +30,7 @@ namespace System.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
                               var ie = default(IAsyncEnumerator<TResult>);
@@ -70,7 +70,7 @@ namespace System.Linq
                                           return false;
                                       };
 
-                              return Create(ct => ie == null ? outer(cts.Token) : inner(cts.Token),
+                              return CreateEnumerator(ct => ie == null ? outer(cts.Token) : inner(cts.Token),
                                             () => ie.Current,
                                             d.Dispose,
                                             e
@@ -85,7 +85,7 @@ namespace System.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
                               var ie = default(IAsyncEnumerator<TResult>);
@@ -127,7 +127,7 @@ namespace System.Linq
                                           return false;
                                       };
 
-                              return Create(ct => ie == null ? outer(cts.Token) : inner(cts.Token),
+                              return CreateEnumerator(ct => ie == null ? outer(cts.Token) : inner(cts.Token),
                                             () => ie.Current,
                                             d.Dispose,
                                             e

--- a/Ix.NET/Source/System.Interactive.Async/SelectMany.cs
+++ b/Ix.NET/Source/System.Interactive.Async/SelectMany.cs
@@ -30,52 +30,53 @@ namespace System.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = source.GetEnumerator();
-                              var ie = default(IAsyncEnumerator<TResult>);
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = source.GetEnumerator();
+                    var ie = default(IAsyncEnumerator<TResult>);
 
-                              var innerDisposable = new AssignableDisposable();
+                    var innerDisposable = new AssignableDisposable();
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, innerDisposable, e);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, innerDisposable, e);
 
-                              var inner = default(Func<CancellationToken, Task<bool>>);
-                              var outer = default(Func<CancellationToken, Task<bool>>);
+                    var inner = default(Func<CancellationToken, Task<bool>>);
+                    var outer = default(Func<CancellationToken, Task<bool>>);
 
-                              inner = async ct =>
-                                      {
-                                          if (await ie.MoveNext(ct)
-                                                      .ConfigureAwait(false))
-                                          {
-                                              return true;
-                                          }
-                                          innerDisposable.Disposable = null;
-                                          return await outer(ct)
-                                                     .ConfigureAwait(false);
-                                      };
+                    inner = async ct =>
+                            {
+                                if (await ie.MoveNext(ct)
+                                            .ConfigureAwait(false))
+                                {
+                                    return true;
+                                }
+                                innerDisposable.Disposable = null;
+                                return await outer(ct)
+                                           .ConfigureAwait(false);
+                            };
 
-                              outer = async ct =>
-                                      {
-                                          if (await e.MoveNext(ct)
-                                                     .ConfigureAwait(false))
-                                          {
-                                              var enumerable = selector(e.Current);
-                                              ie = enumerable.GetEnumerator();
-                                              innerDisposable.Disposable = ie;
+                    outer = async ct =>
+                            {
+                                if (await e.MoveNext(ct)
+                                           .ConfigureAwait(false))
+                                {
+                                    var enumerable = selector(e.Current);
+                                    ie = enumerable.GetEnumerator();
+                                    innerDisposable.Disposable = ie;
 
-                                              return await inner(ct)
-                                                         .ConfigureAwait(false);
-                                          }
-                                          return false;
-                                      };
+                                    return await inner(ct)
+                                               .ConfigureAwait(false);
+                                }
+                                return false;
+                            };
 
-                              return CreateEnumerator(ct => ie == null ? outer(cts.Token) : inner(cts.Token),
+                    return CreateEnumerator(ct => ie == null ? outer(cts.Token) : inner(cts.Token),
                                             () => ie.Current,
                                             d.Dispose,
                                             e
-                              );
-                          });
+                    );
+                });
         }
 
         public static IAsyncEnumerable<TResult> SelectMany<TSource, TResult>(this IAsyncEnumerable<TSource> source, Func<TSource, int, IAsyncEnumerable<TResult>> selector)
@@ -85,54 +86,55 @@ namespace System.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = source.GetEnumerator();
-                              var ie = default(IAsyncEnumerator<TResult>);
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = source.GetEnumerator();
+                    var ie = default(IAsyncEnumerator<TResult>);
 
-                              var index = 0;
+                    var index = 0;
 
-                              var innerDisposable = new AssignableDisposable();
+                    var innerDisposable = new AssignableDisposable();
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, innerDisposable, e);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, innerDisposable, e);
 
-                              var inner = default(Func<CancellationToken, Task<bool>>);
-                              var outer = default(Func<CancellationToken, Task<bool>>);
+                    var inner = default(Func<CancellationToken, Task<bool>>);
+                    var outer = default(Func<CancellationToken, Task<bool>>);
 
-                              inner = async ct =>
-                                      {
-                                          if (await ie.MoveNext(ct)
-                                                      .ConfigureAwait(false))
-                                          {
-                                              return true;
-                                          }
-                                          innerDisposable.Disposable = null;
-                                          return await outer(ct)
-                                                     .ConfigureAwait(false);
-                                      };
+                    inner = async ct =>
+                            {
+                                if (await ie.MoveNext(ct)
+                                            .ConfigureAwait(false))
+                                {
+                                    return true;
+                                }
+                                innerDisposable.Disposable = null;
+                                return await outer(ct)
+                                           .ConfigureAwait(false);
+                            };
 
-                              outer = async ct =>
-                                      {
-                                          if (await e.MoveNext(ct)
-                                                     .ConfigureAwait(false))
-                                          {
-                                              var enumerable = selector(e.Current, checked(index++));
-                                              ie = enumerable.GetEnumerator();
-                                              innerDisposable.Disposable = ie;
+                    outer = async ct =>
+                            {
+                                if (await e.MoveNext(ct)
+                                           .ConfigureAwait(false))
+                                {
+                                    var enumerable = selector(e.Current, checked(index++));
+                                    ie = enumerable.GetEnumerator();
+                                    innerDisposable.Disposable = ie;
 
-                                              return await inner(ct)
-                                                         .ConfigureAwait(false);
-                                          }
-                                          return false;
-                                      };
+                                    return await inner(ct)
+                                               .ConfigureAwait(false);
+                                }
+                                return false;
+                            };
 
-                              return CreateEnumerator(ct => ie == null ? outer(cts.Token) : inner(cts.Token),
+                    return CreateEnumerator(ct => ie == null ? outer(cts.Token) : inner(cts.Token),
                                             () => ie.Current,
                                             d.Dispose,
                                             e
-                              );
-                          });
+                    );
+                });
         }
 
         public static IAsyncEnumerable<TResult> SelectMany<TSource, TCollection, TResult>(this IAsyncEnumerable<TSource> source, Func<TSource, IAsyncEnumerable<TCollection>> selector, Func<TSource, TCollection, TResult> resultSelector)

--- a/Ix.NET/Source/System.Interactive.Async/Skip.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Skip.cs
@@ -19,7 +19,7 @@ namespace System.Linq
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
                               var n = count;
@@ -45,7 +45,7 @@ namespace System.Linq
                                                  .ConfigureAwait(false);
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   ct => f(cts.Token),
                                   () => e.Current,
                                   d.Dispose,
@@ -61,7 +61,7 @@ namespace System.Linq
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
 
@@ -91,7 +91,7 @@ namespace System.Linq
                                       return false;
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   f,
                                   () => current,
                                   d.Dispose,
@@ -107,7 +107,7 @@ namespace System.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
                               var skipping = true;
@@ -135,7 +135,7 @@ namespace System.Linq
                                                     .ConfigureAwait(false);
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   f,
                                   () => e.Current,
                                   d.Dispose,
@@ -151,7 +151,7 @@ namespace System.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
                               var skipping = true;
@@ -180,7 +180,7 @@ namespace System.Linq
                                                     .ConfigureAwait(false);
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   f,
                                   () => e.Current,
                                   d.Dispose,

--- a/Ix.NET/Source/System.Interactive.Async/Skip.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Skip.cs
@@ -19,39 +19,40 @@ namespace System.Linq
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = source.GetEnumerator();
-                              var n = count;
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = source.GetEnumerator();
+                    var n = count;
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, e);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, e);
 
-                              var f = default(Func<CancellationToken, Task<bool>>);
-                              f = async ct =>
-                                  {
-                                      var moveNext = await e.MoveNext(ct)
-                                                            .ConfigureAwait(false);
-                                      if (n == 0)
-                                      {
-                                          return moveNext;
-                                      }
-                                      --n;
-                                      if (!moveNext)
-                                      {
-                                          return false;
-                                      }
-                                      return await f(ct)
-                                                 .ConfigureAwait(false);
-                                  };
+                    var f = default(Func<CancellationToken, Task<bool>>);
+                    f = async ct =>
+                        {
+                            var moveNext = await e.MoveNext(ct)
+                                                  .ConfigureAwait(false);
+                            if (n == 0)
+                            {
+                                return moveNext;
+                            }
+                            --n;
+                            if (!moveNext)
+                            {
+                                return false;
+                            }
+                            return await f(ct)
+                                       .ConfigureAwait(false);
+                        };
 
-                              return CreateEnumerator(
-                                  ct => f(cts.Token),
-                                  () => e.Current,
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator(
+                        ct => f(cts.Token),
+                        () => e.Current,
+                        d.Dispose,
+                        e
+                    );
+                });
         }
 
         public static IAsyncEnumerable<TSource> SkipLast<TSource>(this IAsyncEnumerable<TSource> source, int count)
@@ -61,43 +62,44 @@ namespace System.Linq
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = source.GetEnumerator();
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = source.GetEnumerator();
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, e);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, e);
 
-                              var q = new Queue<TSource>();
-                              var current = default(TSource);
+                    var q = new Queue<TSource>();
+                    var current = default(TSource);
 
-                              var f = default(Func<CancellationToken, Task<bool>>);
-                              f = async ct =>
-                                  {
-                                      if (await e.MoveNext(ct)
-                                                 .ConfigureAwait(false))
-                                      {
-                                          var item = e.Current;
+                    var f = default(Func<CancellationToken, Task<bool>>);
+                    f = async ct =>
+                        {
+                            if (await e.MoveNext(ct)
+                                       .ConfigureAwait(false))
+                            {
+                                var item = e.Current;
 
-                                          q.Enqueue(item);
-                                          if (q.Count > count)
-                                          {
-                                              current = q.Dequeue();
-                                              return true;
-                                          }
-                                          return await f(ct)
-                                                     .ConfigureAwait(false);
-                                      }
-                                      return false;
-                                  };
+                                q.Enqueue(item);
+                                if (q.Count > count)
+                                {
+                                    current = q.Dequeue();
+                                    return true;
+                                }
+                                return await f(ct)
+                                           .ConfigureAwait(false);
+                            }
+                            return false;
+                        };
 
-                              return CreateEnumerator(
-                                  f,
-                                  () => current,
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator(
+                        f,
+                        () => current,
+                        d.Dispose,
+                        e
+                    );
+                });
         }
 
         public static IAsyncEnumerable<TSource> SkipWhile<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate)
@@ -107,41 +109,42 @@ namespace System.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = source.GetEnumerator();
-                              var skipping = true;
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = source.GetEnumerator();
+                    var skipping = true;
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, e);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, e);
 
-                              var f = default(Func<CancellationToken, Task<bool>>);
-                              f = async ct =>
-                                  {
-                                      if (skipping)
-                                      {
-                                          if (await e.MoveNext(ct)
-                                                     .ConfigureAwait(false))
-                                          {
-                                              if (predicate(e.Current))
-                                                  return await f(ct)
-                                                             .ConfigureAwait(false);
-                                              skipping = false;
-                                              return true;
-                                          }
-                                          return false;
-                                      }
-                                      return await e.MoveNext(ct)
-                                                    .ConfigureAwait(false);
-                                  };
+                    var f = default(Func<CancellationToken, Task<bool>>);
+                    f = async ct =>
+                        {
+                            if (skipping)
+                            {
+                                if (await e.MoveNext(ct)
+                                           .ConfigureAwait(false))
+                                {
+                                    if (predicate(e.Current))
+                                        return await f(ct)
+                                                   .ConfigureAwait(false);
+                                    skipping = false;
+                                    return true;
+                                }
+                                return false;
+                            }
+                            return await e.MoveNext(ct)
+                                          .ConfigureAwait(false);
+                        };
 
-                              return CreateEnumerator(
-                                  f,
-                                  () => e.Current,
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator(
+                        f,
+                        () => e.Current,
+                        d.Dispose,
+                        e
+                    );
+                });
         }
 
         public static IAsyncEnumerable<TSource> SkipWhile<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, int, bool> predicate)
@@ -151,42 +154,43 @@ namespace System.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = source.GetEnumerator();
-                              var skipping = true;
-                              var index = 0;
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = source.GetEnumerator();
+                    var skipping = true;
+                    var index = 0;
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, e);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, e);
 
-                              var f = default(Func<CancellationToken, Task<bool>>);
-                              f = async ct =>
-                                  {
-                                      if (skipping)
-                                      {
-                                          if (await e.MoveNext(ct)
-                                                     .ConfigureAwait(false))
-                                          {
-                                              if (predicate(e.Current, checked(index++)))
-                                                  return await f(ct)
-                                                             .ConfigureAwait(false);
-                                              skipping = false;
-                                              return true;
-                                          }
-                                          return false;
-                                      }
-                                      return await e.MoveNext(ct)
-                                                    .ConfigureAwait(false);
-                                  };
+                    var f = default(Func<CancellationToken, Task<bool>>);
+                    f = async ct =>
+                        {
+                            if (skipping)
+                            {
+                                if (await e.MoveNext(ct)
+                                           .ConfigureAwait(false))
+                                {
+                                    if (predicate(e.Current, checked(index++)))
+                                        return await f(ct)
+                                                   .ConfigureAwait(false);
+                                    skipping = false;
+                                    return true;
+                                }
+                                return false;
+                            }
+                            return await e.MoveNext(ct)
+                                          .ConfigureAwait(false);
+                        };
 
-                              return CreateEnumerator(
-                                  f,
-                                  () => e.Current,
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator(
+                        f,
+                        () => e.Current,
+                        d.Dispose,
+                        e
+                    );
+                });
         }
     }
 }

--- a/Ix.NET/Source/System.Interactive.Async/Take.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Take.cs
@@ -19,7 +19,7 @@ namespace System.Linq
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
                               var n = count;
@@ -27,7 +27,7 @@ namespace System.Linq
                               var cts = new CancellationTokenDisposable();
                               var d = Disposable.Create(cts, e);
 
-                              return Create(
+                              return CreateEnumerator(
                                   async ct =>
                                   {
                                       if (n == 0)
@@ -57,7 +57,7 @@ namespace System.Linq
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
 
@@ -101,7 +101,7 @@ namespace System.Linq
                                       return false;
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   f,
                                   () => current,
                                   d.Dispose,
@@ -117,14 +117,14 @@ namespace System.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
 
                               var cts = new CancellationTokenDisposable();
                               var d = Disposable.Create(cts, e);
 
-                              return Create(
+                              return CreateEnumerator(
                                   async ct =>
                                   {
                                       if (await e.MoveNext(cts.Token)
@@ -148,7 +148,7 @@ namespace System.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
                               var index = 0;
@@ -156,7 +156,7 @@ namespace System.Linq
                               var cts = new CancellationTokenDisposable();
                               var d = Disposable.Create(cts, e);
 
-                              return Create(
+                              return CreateEnumerator(
                                   async ct =>
                                   {
                                       if (await e.MoveNext(cts.Token)

--- a/Ix.NET/Source/System.Interactive.Async/Take.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Take.cs
@@ -19,35 +19,36 @@ namespace System.Linq
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = source.GetEnumerator();
-                              var n = count;
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = source.GetEnumerator();
+                    var n = count;
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, e);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, e);
 
-                              return CreateEnumerator(
-                                  async ct =>
-                                  {
-                                      if (n == 0)
-                                          return false;
+                    return CreateEnumerator(
+                        async ct =>
+                        {
+                            if (n == 0)
+                                return false;
 
-                                      var result = await e.MoveNext(cts.Token)
-                                                          .ConfigureAwait(false);
+                            var result = await e.MoveNext(cts.Token)
+                                                .ConfigureAwait(false);
 
-                                      --n;
+                            --n;
 
-                                      if (n == 0)
-                                          e.Dispose();
+                            if (n == 0)
+                                e.Dispose();
 
-                                      return result;
-                                  },
-                                  () => e.Current,
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                            return result;
+                        },
+                        () => e.Current,
+                        d.Dispose,
+                        e
+                    );
+                });
         }
 
         public static IAsyncEnumerable<TSource> TakeLast<TSource>(this IAsyncEnumerable<TSource> source, int count)
@@ -57,57 +58,58 @@ namespace System.Linq
             if (count < 0)
                 throw new ArgumentOutOfRangeException(nameof(count));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = source.GetEnumerator();
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = source.GetEnumerator();
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, e);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, e);
 
-                              var q = new Queue<TSource>(count);
-                              var done = false;
-                              var current = default(TSource);
+                    var q = new Queue<TSource>(count);
+                    var done = false;
+                    var current = default(TSource);
 
-                              var f = default(Func<CancellationToken, Task<bool>>);
-                              f = async ct =>
-                                  {
-                                      if (!done)
-                                      {
-                                          if (await e.MoveNext(ct)
-                                                     .ConfigureAwait(false))
-                                          {
-                                              if (count > 0)
-                                              {
-                                                  var item = e.Current;
-                                                  if (q.Count >= count)
-                                                      q.Dequeue();
-                                                  q.Enqueue(item);
-                                              }
-                                          }
-                                          else
-                                          {
-                                              done = true;
-                                              e.Dispose();
-                                          }
+                    var f = default(Func<CancellationToken, Task<bool>>);
+                    f = async ct =>
+                        {
+                            if (!done)
+                            {
+                                if (await e.MoveNext(ct)
+                                           .ConfigureAwait(false))
+                                {
+                                    if (count > 0)
+                                    {
+                                        var item = e.Current;
+                                        if (q.Count >= count)
+                                            q.Dequeue();
+                                        q.Enqueue(item);
+                                    }
+                                }
+                                else
+                                {
+                                    done = true;
+                                    e.Dispose();
+                                }
 
-                                          return await f(ct)
-                                                     .ConfigureAwait(false);
-                                      }
-                                      if (q.Count > 0)
-                                      {
-                                          current = q.Dequeue();
-                                          return true;
-                                      }
-                                      return false;
-                                  };
+                                return await f(ct)
+                                           .ConfigureAwait(false);
+                            }
+                            if (q.Count > 0)
+                            {
+                                current = q.Dequeue();
+                                return true;
+                            }
+                            return false;
+                        };
 
-                              return CreateEnumerator(
-                                  f,
-                                  () => current,
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator(
+                        f,
+                        () => current,
+                        d.Dispose,
+                        e
+                    );
+                });
         }
 
         public static IAsyncEnumerable<TSource> TakeWhile<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, bool> predicate)
@@ -117,28 +119,29 @@ namespace System.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = source.GetEnumerator();
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = source.GetEnumerator();
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, e);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, e);
 
-                              return CreateEnumerator(
-                                  async ct =>
-                                  {
-                                      if (await e.MoveNext(cts.Token)
-                                                 .ConfigureAwait(false))
-                                      {
-                                          return predicate(e.Current);
-                                      }
-                                      return false;
-                                  },
-                                  () => e.Current,
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator(
+                        async ct =>
+                        {
+                            if (await e.MoveNext(cts.Token)
+                                       .ConfigureAwait(false))
+                            {
+                                return predicate(e.Current);
+                            }
+                            return false;
+                        },
+                        () => e.Current,
+                        d.Dispose,
+                        e
+                    );
+                });
         }
 
         public static IAsyncEnumerable<TSource> TakeWhile<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, int, bool> predicate)
@@ -148,29 +151,30 @@ namespace System.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = source.GetEnumerator();
-                              var index = 0;
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = source.GetEnumerator();
+                    var index = 0;
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, e);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, e);
 
-                              return CreateEnumerator(
-                                  async ct =>
-                                  {
-                                      if (await e.MoveNext(cts.Token)
-                                                 .ConfigureAwait(false))
-                                      {
-                                          return predicate(e.Current, checked(index++));
-                                      }
-                                      return false;
-                                  },
-                                  () => e.Current,
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator(
+                        async ct =>
+                        {
+                            if (await e.MoveNext(cts.Token)
+                                       .ConfigureAwait(false))
+                            {
+                                return predicate(e.Current, checked(index++));
+                            }
+                            return false;
+                        },
+                        () => e.Current,
+                        d.Dispose,
+                        e
+                    );
+                });
         }
     }
 }

--- a/Ix.NET/Source/System.Interactive.Async/ToAsyncEnumerable.cs
+++ b/Ix.NET/Source/System.Interactive.Async/ToAsyncEnumerable.cs
@@ -15,11 +15,11 @@ namespace System.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
             {
                 var e = source.GetEnumerator();
 
-                return Create(
+                return CreateEnumerator(
                     ct => Task.Run(() =>
                     {
                         var res = false;
@@ -67,12 +67,12 @@ namespace System.Linq
             if (task == null)
                 throw new ArgumentNullException(nameof(task));
             
-            return Create(() =>
+            return CreateEnumerable(() =>
             {
                 var called = 0;
 
                 var value = default(TSource);
-                return Create(
+                return CreateEnumerator(
                     async ct =>
                     {
                         if (Interlocked.CompareExchange(ref called, 1, 0) == 0)

--- a/Ix.NET/Source/System.Interactive.Async/ToAsyncEnumerable.cs
+++ b/Ix.NET/Source/System.Interactive.Async/ToAsyncEnumerable.cs
@@ -1,10 +1,12 @@
 ﻿// Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information. 
+
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
+using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace System.Linq
 {
@@ -15,29 +17,56 @@ namespace System.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return CreateEnumerable(() =>
-            {
-                var e = source.GetEnumerator();
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = source.GetEnumerator();
 
-                return CreateEnumerator(
-                    ct => Task.Run(() =>
-                    {
-                        var res = false;
-                        try
+                    return CreateEnumerator(
+                        ct => Task.Run(() =>
+                                       {
+                                           var res = false;
+                                           try
+                                           {
+                                               res = e.MoveNext();
+                                           }
+                                           finally
+                                           {
+                                               if (!res)
+                                                   e.Dispose();
+                                           }
+                                           return res;
+                                       }, ct),
+                        () => e.Current,
+                        () => e.Dispose()
+                    );
+                });
+        }
+
+        public static IAsyncEnumerable<TSource> ToAsyncEnumerable<TSource>(this Task<TSource> task)
+        {
+            if (task == null)
+                throw new ArgumentNullException(nameof(task));
+
+            return CreateEnumerable(
+                () =>
+                {
+                    var called = 0;
+
+                    var value = default(TSource);
+                    return CreateEnumerator(
+                        async ct =>
                         {
-                            res = e.MoveNext();
-                        }
-                        finally
-                        {
-                            if (!res)
-                                e.Dispose();
-                        }
-                        return res;
-                    }, ct),
-                    () => e.Current,
-                    () => e.Dispose()
-                );
-            });
+                            if (Interlocked.CompareExchange(ref called, 1, 0) == 0)
+                            {
+                                value = await task.ConfigureAwait(false);
+                                return true;
+                            }
+                            return false;
+                        },
+                        () => value,
+                        () => { });
+                });
         }
 
         public static IEnumerable<TSource> ToEnumerable<TSource>(this IAsyncEnumerable<TSource> source)
@@ -54,39 +83,13 @@ namespace System.Linq
             {
                 while (true)
                 {
-                    if (!e.MoveNext(CancellationToken.None).Result)
+                    if (!e.MoveNext(CancellationToken.None)
+                          .Result)
                         break;
                     var c = e.Current;
                     yield return c;
                 }
             }
         }
-
-        public static IAsyncEnumerable<TSource> ToAsyncEnumerable<TSource>(this Task<TSource> task)
-        {
-            if (task == null)
-                throw new ArgumentNullException(nameof(task));
-            
-            return CreateEnumerable(() =>
-            {
-                var called = 0;
-
-                var value = default(TSource);
-                return CreateEnumerator(
-                    async ct =>
-                    {
-                        if (Interlocked.CompareExchange(ref called, 1, 0) == 0)
-                        {
-                            value = await task.ConfigureAwait(false);
-                            return true;
-                        }
-                        return false;
-                    },
-                    () => value,
-                    () => { });
-            });
-        }
-
-
     }
 }

--- a/Ix.NET/Source/System.Interactive.Async/ToObservable.cs
+++ b/Ix.NET/Source/System.Interactive.Async/ToObservable.cs
@@ -16,13 +16,13 @@ namespace System.Linq
             if (source == null)
                 throw new ArgumentNullException(nameof(source));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var observer = new ToAsyncEnumerableObserver<TSource>();
 
                               var subscription = source.Subscribe(observer);
 
-                              return Create(
+                              return CreateEnumerator(
                                   (ct, tcs) =>
                                   {
                                       var hasValue = false;

--- a/Ix.NET/Source/System.Interactive.Async/Using.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Using.cs
@@ -18,7 +18,7 @@ namespace System.Linq
             if (enumerableFactory == null)
                 throw new ArgumentNullException(nameof(enumerableFactory));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var resource = resourceFactory();
                               var e = default(IAsyncEnumerator<TSource>);
@@ -39,7 +39,7 @@ namespace System.Linq
 
                               var current = default(TSource);
 
-                              return Create(
+                              return CreateEnumerator(
                                   async ct =>
                                   {
                                       bool res;

--- a/Ix.NET/Source/System.Interactive.Async/Where.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Where.cs
@@ -19,7 +19,7 @@ namespace System.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
 
@@ -40,7 +40,7 @@ namespace System.Linq
                                       return false;
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   ct => f(cts.Token),
                                   () => e.Current,
                                   d.Dispose,
@@ -56,7 +56,7 @@ namespace System.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e = source.GetEnumerator();
                               var index = 0;
@@ -78,7 +78,7 @@ namespace System.Linq
                                       return false;
                                   };
 
-                              return Create(
+                              return CreateEnumerator(
                                   ct => f(cts.Token),
                                   () => e.Current,
                                   d.Dispose,

--- a/Ix.NET/Source/System.Interactive.Async/Where.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Where.cs
@@ -19,34 +19,35 @@ namespace System.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = source.GetEnumerator();
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = source.GetEnumerator();
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, e);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, e);
 
-                              var f = default(Func<CancellationToken, Task<bool>>);
-                              f = async ct =>
-                                  {
-                                      if (await e.MoveNext(ct)
-                                                 .ConfigureAwait(false))
-                                      {
-                                          if (predicate(e.Current))
-                                              return true;
-                                          return await f(ct)
-                                                     .ConfigureAwait(false);
-                                      }
-                                      return false;
-                                  };
+                    var f = default(Func<CancellationToken, Task<bool>>);
+                    f = async ct =>
+                        {
+                            if (await e.MoveNext(ct)
+                                       .ConfigureAwait(false))
+                            {
+                                if (predicate(e.Current))
+                                    return true;
+                                return await f(ct)
+                                           .ConfigureAwait(false);
+                            }
+                            return false;
+                        };
 
-                              return CreateEnumerator(
-                                  ct => f(cts.Token),
-                                  () => e.Current,
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator(
+                        ct => f(cts.Token),
+                        () => e.Current,
+                        d.Dispose,
+                        e
+                    );
+                });
         }
 
         public static IAsyncEnumerable<TSource> Where<TSource>(this IAsyncEnumerable<TSource> source, Func<TSource, int, bool> predicate)
@@ -56,35 +57,36 @@ namespace System.Linq
             if (predicate == null)
                 throw new ArgumentNullException(nameof(predicate));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e = source.GetEnumerator();
-                              var index = 0;
+            return CreateEnumerable(
+                () =>
+                {
+                    var e = source.GetEnumerator();
+                    var index = 0;
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, e);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, e);
 
-                              var f = default(Func<CancellationToken, Task<bool>>);
-                              f = async ct =>
-                                  {
-                                      if (await e.MoveNext(ct)
-                                                 .ConfigureAwait(false))
-                                      {
-                                          if (predicate(e.Current, checked(index++)))
-                                              return true;
-                                          return await f(ct)
-                                                     .ConfigureAwait(false);
-                                      }
-                                      return false;
-                                  };
+                    var f = default(Func<CancellationToken, Task<bool>>);
+                    f = async ct =>
+                        {
+                            if (await e.MoveNext(ct)
+                                       .ConfigureAwait(false))
+                            {
+                                if (predicate(e.Current, checked(index++)))
+                                    return true;
+                                return await f(ct)
+                                           .ConfigureAwait(false);
+                            }
+                            return false;
+                        };
 
-                              return CreateEnumerator(
-                                  ct => f(cts.Token),
-                                  () => e.Current,
-                                  d.Dispose,
-                                  e
-                              );
-                          });
+                    return CreateEnumerator(
+                        ct => f(cts.Token),
+                        () => e.Current,
+                        d.Dispose,
+                        e
+                    );
+                });
         }
     }
 }

--- a/Ix.NET/Source/System.Interactive.Async/Zip.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Zip.cs
@@ -20,28 +20,30 @@ namespace System.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return CreateEnumerable(() =>
-                          {
-                              var e1 = first.GetEnumerator();
-                              var e2 = second.GetEnumerator();
-                              var current = default(TResult);
+            return CreateEnumerable(
+                () =>
+                {
+                    var e1 = first.GetEnumerator();
+                    var e2 = second.GetEnumerator();
+                    var current = default(TResult);
 
-                              var cts = new CancellationTokenDisposable();
-                              var d = Disposable.Create(cts, e1, e2);
+                    var cts = new CancellationTokenDisposable();
+                    var d = Disposable.Create(cts, e1, e2);
 
-                              return CreateEnumerator(
-                                  ct => e1.MoveNext(cts.Token)
-                                          .Zip(e2.MoveNext(cts.Token), (f, s) =>
-                                                                       {
-                                                                           var result = f && s;
-                                                                           if (result)
-                                                                               current = selector(e1.Current, e2.Current);
-                                                                           return result;
-                                                                       }),
-                                  () => current,
-                                  d.Dispose
-                              );
-                          });
+                    return CreateEnumerator(
+                        ct => e1.MoveNext(cts.Token)
+                                .Zip(e2.MoveNext(cts.Token),
+                                     (f, s) =>
+                                     {
+                                         var result = f && s;
+                                         if (result)
+                                             current = selector(e1.Current, e2.Current);
+                                         return result;
+                                     }),
+                        () => current,
+                        d.Dispose
+                    );
+                });
         }
     }
 }

--- a/Ix.NET/Source/System.Interactive.Async/Zip.cs
+++ b/Ix.NET/Source/System.Interactive.Async/Zip.cs
@@ -20,7 +20,7 @@ namespace System.Linq
             if (selector == null)
                 throw new ArgumentNullException(nameof(selector));
 
-            return Create(() =>
+            return CreateEnumerable(() =>
                           {
                               var e1 = first.GetEnumerator();
                               var e2 = second.GetEnumerator();
@@ -29,7 +29,7 @@ namespace System.Linq
                               var cts = new CancellationTokenDisposable();
                               var d = Disposable.Create(cts, e1, e2);
 
-                              return Create(
+                              return CreateEnumerator(
                                   ct => e1.MoveNext(cts.Token)
                                           .Zip(e2.MoveNext(cts.Token), (f, s) =>
                                                                        {

--- a/Ix.NET/Source/Tests/Tests.Qbservable.cs
+++ b/Ix.NET/Source/Tests/Tests.Qbservable.cs
@@ -63,7 +63,7 @@ namespace Tests
                     .Select(m => GetSignature(m, true))
                     .OrderBy(x => x).ToList();
 
-                if (!(group.Name.Equals("CreateEnumerable") || group.Name.Equals("CreateEnumerator")))
+                if (!group.Name.Equals("Create"))
                     Assert.True(oss.SequenceEqual(qss), "Mismatch between QueryableEx and EnumerableEx for " + group.Name);
             }
         }

--- a/Ix.NET/Source/Tests/Tests.Qbservable.cs
+++ b/Ix.NET/Source/Tests/Tests.Qbservable.cs
@@ -63,7 +63,7 @@ namespace Tests
                     .Select(m => GetSignature(m, true))
                     .OrderBy(x => x).ToList();
 
-                if (!group.Name.Equals("Create"))
+                if (!(group.Name.Equals("CreateEnumerable") || group.Name.Equals("CreateEnumerator")))
                     Assert.True(oss.SequenceEqual(qss), "Mismatch between QueryableEx and EnumerableEx for " + group.Name);
             }
         }


### PR DESCRIPTION
This PR implements #228 to split `Create` into `CreateEnumerable` and `CreateEnumerator` to improve readability.