### PR TITLE
Lock free SerialDisposable

### DIFF
--- a/Rx.NET/Source/Tests.System.Reactive/Tests/Disposables/DisposableTests.cs
+++ b/Rx.NET/Source/Tests.System.Reactive/Tests/Disposables/DisposableTests.cs
@@ -511,7 +511,7 @@ namespace ReactiveTests.Tests
             m.Dispose();
             Assert.True(m.IsDisposed);
             Assert.True(disp);
-            //Assert.Null(m.Disposable); // BREAKING CHANGE v2 > v1.x - Undefined behavior after disposal.
+            Assert.Null(m.Disposable);   // At v1.1 Behaviour after disposal was undefined. v3 can now enforce the breaking change behavior from 1.1->2.0
         }
 
         [Fact]


### PR DESCRIPTION
Makes the internal implementation of `SerialDisposable` a lock free and wait free implementation.

The design is fairly simple. As the object can only be in one of two states (Active or Disposed), these two states are represented internally as two separate implementations. While active, the setting of the `Disposable` property just executes an atomic exchange of the old value for the new value. The old value is disposed.

When an instance of `SerialDisposable` is disposed, it migrates to its disposed state by performing an atomic exchange of the internal implementations.

While the goal of this is a performance improvement, it is in the realms of _marginal gains_. I don't expect a perceivable difference in performance for the Rx code base. However my theory is if it can run faster, with no other observable changes in the behavior or API, then it is a win. If this PR is accepted, then perhaps other areas of the Rx code base can be targeted too.

Performance tests across various x86 (mobile) processors (Atom, i3, i5 & i7) there is a performance improvement. With the notable exception of when running throughput test on an i7 with 2 threads there is a performance drop. i.e. of the 24 variations of tests this was the only variation that showed a reduction (~12%) in performance. All other variations (1 - 9 threads for i7 and 1-5 threads for i5, i3 and Atom processors) showed performance increase from 12% to 180%.

Single-threaded performance all showed between 81-99% improvement. Running two threads was the worst performance increase for for the i7, i5 and i3 processors. Generally best performance gains were seen when the number of threads matched the number of logical cores.

What we are really seeing is that the lock free implementation has much better single threaded performance and consistent contended performance in contrast to the existing implementation that has degrading performance as contention increases.

# Summary results
Measurements are Operations per second, where an operation is just assigning a `BooleanDisposable` to the `SerialDisposable.Disposable` property. e.g `24M` is 24,000,000 operations per second. The summaries below round down to the nearest million. The full test data is attached.

## I7-4702HQ@2.20GHZ	

	Threads		   1       2       3	   4	   5	   6	   7	   8	   9
	--------------------------------------------------------------------------------
	Existing	 29M	 24M	 19M	 20M	 20M   	 20M     18M	 12M	 13M
	Lockfree	 59M	 21M	 24M	 22M 	 24M	 28M	 29M	 31M	 29M
	--------------------------------------------------------------------------------
	Scaled		1.99	0.88	1.25	1.12	1.18	1.42	1.56	2.43	2.26

## I5-3317U@1.70GHZ

	Threads		   1       2       3	   4	   5
	------------------------------------------------
	Existing	 22M	 17M	 15M	 10M	 10M
	Lockfree	 43M	 22M	 20M	 26M	 28M	
	------------------------------------------------
	Scaled		1.93	1.27	1.31	2.39	2.80

## I3-2365M@1.40GHZ

	Threads		   1       2       3	   4	   5
	------------------------------------------------
	Existing	 13M	  9M	  7M	  6M	  5M
	Lockfree	 23M	 12M	 13M	 16M	 14M
	------------------------------------------------
	Scaled		1.81	1.36	1.94	2.64	2.58

## ATOMZ2760@1.80GHZ

	Threads		   1       2       3	   4	   5
	------------------------------------------------
	Existing	  7M	  3M	  3M	  3M	  3M
	Lockfree	 14M	  6M	  8M	  8M	  8M
	------------------------------------------------
	Scaled		1.91	1.98	2.16	2.60	2.63

[SerialDisposable Results.xlsx](https://github.com/Reactive-Extensions/Rx.NET/files/392337/SerialDisposable.Results.xlsx)

Test source code available here - https://github.com/LeeCampbell/RxPerfTests/tree/c37dc941d8cbfe381c85b5595a0b2d1da9381db6
