### PR TITLE
Fix WithLatestFrom potential memory visibility issues

### DIFF
--- a/Rx.NET/Source/System.Reactive.Linq/Reactive/Linq/Observable/WithLatestFrom.cs
+++ b/Rx.NET/Source/System.Reactive.Linq/Reactive/Linq/Observable/WithLatestFrom.cs
@@ -40,9 +40,10 @@ namespace System.Reactive.Linq.ObservableImpl
             }
 
             private object _gate;
-            private object _latestGate;
-            private volatile bool hasLatest;
+            private volatile bool _hasLatest;
             private TSecond _latest;
+
+            private object _latestGate;
 
             public IDisposable Run()
             {
@@ -89,7 +90,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public void OnNext(TFirst value)
                 {
-                    if (_parent.hasLatest)
+                    if (_parent._hasLatest)
                     {
 
                         TSecond latest;
@@ -156,9 +157,9 @@ namespace System.Reactive.Linq.ObservableImpl
                         _parent._latest = value;
                     }
 
-                    if (!_parent.hasLatest)
+                    if (!_parent._hasLatest)
                     {
-                        _parent.hasLatest = true;
+                        _parent._hasLatest = true;
                     }
                 }
             }

--- a/Rx.NET/Source/System.Reactive.Linq/Reactive/Linq/Observable/WithLatestFrom.cs
+++ b/Rx.NET/Source/System.Reactive.Linq/Reactive/Linq/Observable/WithLatestFrom.cs
@@ -90,7 +90,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
                 public void OnNext(TFirst value)
                 {
-                    if (_parent._hasLatest)
+                    if (_parent._hasLatest) // Volatile read
                     {
 
                         TSecond latest;


### PR DESCRIPTION
As I reported in #227, setting a volatile `hasLatest` doesn't ensure proper visibility of the latest value and one needs at least an ordered store for the whole element (by boxing it and writing the reference in with an ordered store).

**Cost of correctness**: one boxing and one unboxing of structure types.

**Possible tradeoff choice**: using `Volatile.Write` instead of `Interlocked.Exchange`; both are correct but the former may only become visible a bit delayed (once the CPU write buffer is emitted) whereas the latter is "immediately" visible to other cores.