### PR TITLE
In AsyncIterator.Dispose, check whether cancellationTokenSource is null

### DIFF
--- a/Ix.NET/Source/System.Interactive.Async/AsyncIterator.cs
+++ b/Ix.NET/Source/System.Interactive.Async/AsyncIterator.cs
@@ -48,11 +48,14 @@ namespace System.Linq
 
             public virtual void Dispose()
             {
-                if (!cancellationTokenSource.IsCancellationRequested)
+                if (cancellationTokenSource != null)
                 {
-                    cancellationTokenSource.Cancel();
+                    if (!cancellationTokenSource.IsCancellationRequested)
+                    {
+                        cancellationTokenSource.Cancel();
+                    }
+                    cancellationTokenSource.Dispose();
                 }
-                cancellationTokenSource.Dispose();
 
                 current = default(TSource);
                 state = AsyncIteratorState.Disposed;

--- a/Ix.NET/Source/Tests/AsyncTests.Bugs.cs
+++ b/Ix.NET/Source/Tests/AsyncTests.Bugs.cs
@@ -377,6 +377,13 @@ namespace Tests
             Assert.True(disposes.All(d => d.DisposeCount == 1));
         }
 
+        [Fact]
+        public void DisposeAfterCreation()
+        {
+            var enumerable = AsyncEnumerable.Return(0) as IDisposable;
+            enumerable?.Dispose();
+        }
+
         private class DisposeCounter : IAsyncEnumerable<object>
         {
             public int DisposeCount { get; private set; }


### PR DESCRIPTION
Since AsyncIterator is not public, the problem here only arises when a reference of AsyncIterator is explicitly cast to IDisposable and disposed of - in IoC-containers like Autofac, this is a common scenario since it keeps track of all created disposables so this is gonna explode somewhere without this fix.