### PR TITLE
Let IOrderedAsyncQueryable<T> implement IOrderedAsyncQueryable

### DIFF
--- a/Ix.NET/Source/System.Interactive.Async.Providers/IOrderedAsyncQueryable.cs
+++ b/Ix.NET/Source/System.Interactive.Async.Providers/IOrderedAsyncQueryable.cs
@@ -14,7 +14,7 @@ namespace System.Linq
     /// Ordered asynchronous enumerable sequence represented by an expression tree.
     /// </summary>
     /// <typeparam name="T">The type of the elements in the sequence.</typeparam>
-    public interface IOrderedAsyncQueryable<out T> : IAsyncQueryable<T>
+    public interface IOrderedAsyncQueryable<out T> : IAsyncQueryable<T>, IOrderedAsyncQueryable
     {
     }
 }

--- a/Ix.NET/Source/Tests/AsyncEnumerableQueryTest.cs
+++ b/Ix.NET/Source/Tests/AsyncEnumerableQueryTest.cs
@@ -1,0 +1,24 @@
+using System.Linq;
+using Xunit;
+
+namespace Tests
+{
+    public class AsyncEnumerableQueryTest
+    {
+        [Fact]
+        public void CastToUntypedIAsyncQueryable()
+        {
+            var query = Enumerable.Empty<string>().ToAsyncEnumerable().AsAsyncQueryable();
+
+            Assert.IsAssignableFrom<IAsyncQueryable>(query);
+        }
+
+        [Fact]
+        public void CastToUntypedIOrderedAsyncQueryable()
+        {
+            var query = Enumerable.Empty<string>().ToAsyncEnumerable().AsAsyncQueryable().OrderBy(s => s.Length);
+
+            Assert.IsAssignableFrom<IOrderedAsyncQueryable>(query);
+        }
+    }
+}


### PR DESCRIPTION
If a class like AsyncEnumerableQuery implements IOrderedAsyncQueryable<T>, it does not automatically implement IOrderedAsyncQueryable<T>, which can be a problem within untyped code.

Fixes #301
