### PR TITLE
When converting an IAsyncEnumerable to an IObservable, unwrap the AggregateException that may be thrown by IAsyncEnumerable.MoveNext.

### DIFF
--- a/Ix.NET/Source/System.Interactive.Async/ToObservable.cs
+++ b/Ix.NET/Source/System.Interactive.Async/ToObservable.cs
@@ -190,7 +190,7 @@ namespace System.Linq
                                          {
                                              if (t.IsFaulted)
                                              {
-                                                 observer.OnError(t.Exception);
+                                                 observer.OnError(t.Exception.InnerExceptions.Single());
                                                  e.Dispose();
                                              }
                                              else if (t.IsCanceled)

--- a/Ix.NET/Source/Tests/AsyncTests.Conversions.cs
+++ b/Ix.NET/Source/Tests/AsyncTests.Conversions.cs
@@ -440,7 +440,7 @@ namespace Tests
 
             evt.WaitOne();
             Assert.False(fail);
-            Assert.Equal(ex1, ((AggregateException)ex_).InnerExceptions.Single());
+            Assert.Equal(ex1, ex_);
         }
 
         [Fact]


### PR DESCRIPTION
This may be considered a breaking change. When converting an IAsyncEnumerable into an IObservable, AggregateExceptions thrown by IAsyncEnumerator.MoveNext should be unwrapped before being passed to OnError. Justifications:

- A user of the resulting IObservable cannot anticipate any AggregateExceptions, much less the level of nesting when repeatedly converting.
- If ToObservable would be implemented using async/await, there would be no AggregateExceptions.
- Since the async/await-feature, AggregateExceptions have become less useful. In fact, async state machines also only rethrow the first exception in an AggregateException.