### PR TITLE
AsyncEnumerable.ToObservable: Use Try...-methods on TaskCompletionSources to avoid unexpected exceptions when the iterator is cancelled.

### DIFF
--- a/Ix.NET/Source/System.Interactive.Async/ToObservable.cs
+++ b/Ix.NET/Source/System.Interactive.Async/ToObservable.cs
@@ -119,7 +119,7 @@ namespace System.Linq
 
                 if (tcs != null)
                 {
-                    tcs.SetResult(false);
+                    tcs.TrySetResult(false);
                 }
             }
 
@@ -140,7 +140,7 @@ namespace System.Linq
 
                 if (tcs != null)
                 {
-                    tcs.SetException(error);
+                    tcs.TrySetException(error);
                 }
             }
 
@@ -165,7 +165,7 @@ namespace System.Linq
 
                 if (tcs != null)
                 {
-                    tcs.SetResult(true);
+                    tcs.TrySetResult(true);
                 }
             }
         }


### PR DESCRIPTION
As described in #319, concurrent cancellation of async iterators may lead to unexpected exceptions. At least in some places (e.g. those where the `Try...` methods of `TaskCompletionSource` may be used), an easy fix is possible.