### PR TITLE
Use of Interlocked on volatile fields no longer raises CS0420

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Disposables/AnonymousDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/AnonymousDisposable.cs
@@ -37,9 +37,7 @@ namespace System.Reactive.Disposables
         /// </summary>
         public void Dispose()
         {
-#pragma warning disable 0420
             var dispose = Interlocked.Exchange(ref _dispose, null);
-#pragma warning restore 0420
             if (dispose != null)
             {
                 dispose();

--- a/Rx.NET/Source/src/System.Reactive/Disposables/ContextDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/ContextDisposable.cs
@@ -54,9 +54,7 @@ namespace System.Reactive.Disposables
         /// </summary>
         public void Dispose()
         {
-#pragma warning disable 0420
             var disposable = Interlocked.Exchange(ref _disposable, BooleanDisposable.True);
-#pragma warning restore 0420
 
             if (disposable != BooleanDisposable.True)
             {

--- a/Rx.NET/Source/src/System.Reactive/Disposables/ScheduledDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/ScheduledDisposable.cs
@@ -74,9 +74,7 @@ namespace System.Reactive.Disposables
 
         private void DisposeInner()
         {
-#pragma warning disable 0420
             var disposable = Interlocked.Exchange(ref _disposable, BooleanDisposable.True);
-#pragma warning restore 0420
 
             if (disposable != BooleanDisposable.True)
             {

--- a/Rx.NET/Source/src/System.Reactive/Disposables/SingleAssignmentDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/SingleAssignmentDisposable.cs
@@ -53,9 +53,7 @@ namespace System.Reactive.Disposables
 
             set
             {
-#pragma warning disable 0420
                 var old = Interlocked.CompareExchange(ref _current, value, null);
-#pragma warning restore 0420
                 if (old == null)
                     return;
 
@@ -72,9 +70,7 @@ namespace System.Reactive.Disposables
         /// </summary>
         public void Dispose()
         {
-#pragma warning disable 0420
             var old = Interlocked.Exchange(ref _current, BooleanDisposable.True);
-#pragma warning restore 0420
             if (old != null)
                 old.Dispose();
         }

--- a/Rx.NET/Source/src/System.Reactive/Disposables/StableCompositeDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/StableCompositeDisposable.cs
@@ -88,17 +88,13 @@ namespace System.Reactive.Disposables
 
             public override void Dispose()
             {
-#pragma warning disable 0420
                 var old1 = Interlocked.Exchange(ref _disposable1, null);
-#pragma warning restore 0420
                 if (old1 != null)
                 {
                     old1.Dispose();
                 }
 
-#pragma warning disable 0420
                 var old2 = Interlocked.Exchange(ref _disposable2, null);
-#pragma warning restore 0420
                 if (old2 != null)
                 {
                     old2.Dispose();
@@ -136,9 +132,7 @@ namespace System.Reactive.Disposables
 
             public override void Dispose()
             {
-#pragma warning disable 0420
                 var old = Interlocked.Exchange(ref _disposables, null);
-#pragma warning restore 0420
                 if (old != null)
                 {
                     foreach (var d in old)

--- a/Rx.NET/Source/src/System.Reactive/Internal/ScheduledObserver.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/ScheduledObserver.cs
@@ -138,7 +138,6 @@ namespace System.Reactive
         {
             var isOwner = false;
 
-#pragma warning disable 0420
             while (true)
             {
                 var old = Interlocked.CompareExchange(ref _state, RUNNING, STOPPED);
@@ -177,7 +176,6 @@ namespace System.Reactive
                 if (old == PENDING || old == RUNNING && Interlocked.CompareExchange(ref _state, PENDING, RUNNING) == RUNNING)
                     break;
             }
-#pragma warning restore 0420
 
             if (isOwner)
             {
@@ -187,7 +185,6 @@ namespace System.Reactive
 
         private void Run(object state, Action<object> recurse)
         {
-#pragma warning disable 0420
             var next = default(T);
             while (!_queue.TryDequeue(out next))
             {
@@ -254,17 +251,13 @@ namespace System.Reactive
 
             Interlocked.Exchange(ref _state, RUNNING);
 
-#pragma warning restore 0420
-
             try
             {
                 _observer.OnNext(next);
             }
             catch
             {
-#pragma warning disable 0420
                 Interlocked.Exchange(ref _state, FAULTED);
-#pragma warning restore 0420
 
                 var nop = default(T);
                 while (_queue.TryDequeue(out nop))

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/Merge.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/Merge.cs
@@ -309,7 +309,6 @@ namespace System.Reactive.Linq.ObservableImpl
         }
 
 #if !NO_TPL
-#pragma warning disable 0420
         class MergeImpl : Sink<TSource>, IObserver<Task<TSource>>
         {
             private readonly Merge<TSource> _parent;
@@ -398,7 +397,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
         }
-#pragma warning restore 0420
 #endif
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/SelectMany.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/SelectMany.cs
@@ -587,7 +587,6 @@ namespace System.Reactive.Linq.ObservableImpl
         }
 
 #if !NO_TPL
-#pragma warning disable 0420
         class SelectManyImpl : Sink<TResult>, IObserver<TSource>
         {
             private readonly SelectMany<TSource, TCollection, TResult> _parent;
@@ -858,7 +857,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
         }
-#pragma warning restore 0420
 #endif
     }
 
@@ -1513,7 +1511,6 @@ namespace System.Reactive.Linq.ObservableImpl
         }
 
 #if !NO_TPL
-#pragma warning disable 0420
         class SelectManyImpl : Sink<TResult>, IObserver<TSource>
         {
             private readonly SelectMany<TSource, TResult> _parent;
@@ -1734,7 +1731,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 }
             }
         }
-#pragma warning restore 0420
 #endif
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Subjects/ReplaySubject.cs
+++ b/Rx.NET/Source/src/System.Reactive/Subjects/ReplaySubject.cs
@@ -982,9 +982,7 @@ namespace System.Reactive.Subjects
         /// <returns>Observer to send terminal notifications to.</returns>
         private IObserver<T> Done()
         {
-#pragma warning disable 0420
             return Interlocked.Exchange(ref _observer, NopObserver<T>.Instance);
-#pragma warning restore 0420
         }
     }
 }

--- a/Rx.NET/Source/src/System.Reactive/Subjects/Subject.cs
+++ b/Rx.NET/Source/src/System.Reactive/Subjects/Subject.cs
@@ -77,9 +77,7 @@ namespace System.Reactive.Subjects
 
                 if (oldObserver == DisposedObserver<T>.Instance || oldObserver is DoneObserver<T>)
                     break;
-#pragma warning disable 0420
             } while (Interlocked.CompareExchange(ref _observer, newObserver, oldObserver) != oldObserver);
-#pragma warning restore 0420
 
             oldObserver.OnCompleted();
         }
@@ -103,9 +101,7 @@ namespace System.Reactive.Subjects
 
                 if (oldObserver == DisposedObserver<T>.Instance || oldObserver is DoneObserver<T>)
                     break;
-#pragma warning disable 0420
             } while (Interlocked.CompareExchange(ref _observer, newObserver, oldObserver) != oldObserver);
-#pragma warning restore 0420
 
             oldObserver.OnError(error);
         }
@@ -175,9 +171,7 @@ namespace System.Reactive.Subjects
                         newObserver = new Observer<T>(new ImmutableList<IObserver<T>>(new[] { oldObserver, observer }));
                     }
                 }
-#pragma warning disable 0420
             } while (Interlocked.CompareExchange(ref _observer, newObserver, oldObserver) != oldObserver);
-#pragma warning restore 0420
 
             return new Subscription(this, observer);
         }
@@ -228,9 +222,7 @@ namespace System.Reactive.Subjects
 
                     newObserver = NopObserver<T>.Instance;
                 }
-#pragma warning disable 0420
             } while (Interlocked.CompareExchange(ref _observer, newObserver, oldObserver) != oldObserver);
-#pragma warning restore 0420
         }
 
         #endregion


### PR DESCRIPTION
These suppressions predate Roslyn where this warning is no longer raised. See https://github.com/dotnet/roslyn/blob/ab534ba4afb74cf4c3fa0748102217eab2f52f9a/src/Compilers/CSharp/Portable/Lowering/DiagnosticsPass_Warnings.cs#L56.