### PR TITLE
Removing checks for absence of HashSet<T>

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Concurrency/ConcurrencyAbstractionLayerImpl.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/ConcurrencyAbstractionLayerImpl.cs
@@ -249,11 +249,7 @@ namespace System.Reactive.Concurrency
             //
             // Note: the dictionary exists to "root" the timers so that they are not garbage collected and finalized while they are running.
             //
-#if !NO_HASHSET
             private static readonly HashSet<System.Threading.Timer> s_timers = new HashSet<System.Threading.Timer>();
-#else
-            private static readonly Dictionary<System.Threading.Timer, object> s_timers = new Dictionary<System.Threading.Timer, object>();
-#endif
 
             private Action<object> _action;
             private System.Threading.Timer _timer;
@@ -270,12 +266,7 @@ namespace System.Reactive.Concurrency
                 {
                     if (!_hasRemoved)
                     {
-#if !NO_HASHSET
                         s_timers.Add(_timer);
-#else
-                        s_timers.Add(_timer, null);
-#endif
-
                         _hasAdded = true;
                     }
                 }
@@ -323,11 +314,7 @@ namespace System.Reactive.Concurrency
             //
             // Note: the dictionary exists to "root" the timers so that they are not garbage collected and finalized while they are running.
             //
-#if !NO_HASHSET
             private static readonly HashSet<System.Threading.Timer> s_timers = new HashSet<System.Threading.Timer>();
-#else
-            private static readonly Dictionary<System.Threading.Timer, object> s_timers = new Dictionary<System.Threading.Timer, object>();
-#endif
 
             private Action _action;
             private System.Threading.Timer _timer;
@@ -339,11 +326,7 @@ namespace System.Reactive.Concurrency
 
                 lock (s_timers)
                 {
-#if !NO_HASHSET
                     s_timers.Add(_timer);
-#else
-                    s_timers.Add(_timer, null);
-#endif
                 }
             }
 

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/LocalScheduler.TimerQueue.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/LocalScheduler.TimerQueue.cs
@@ -55,11 +55,7 @@ namespace System.Reactive.Concurrency
         /// Set of disposable handles to all of the current short term work Schedule calls,
         /// allowing those to be cancelled upon a system clock change.
         /// </summary>
-#if !NO_HASHSET
         private readonly HashSet<IDisposable> _shortTermWork = new HashSet<IDisposable>();
-#else
-        private readonly Dictionary<IDisposable, object> _shortTermWork = new Dictionary<IDisposable, object>();
-#endif
 
         /// <summary>
         /// Threshold where an item is considered to be short term work or gets moved from
@@ -191,11 +187,7 @@ namespace System.Reactive.Concurrency
                 // of WorkItem.Invoke.
                 //
                 var d = new SingleAssignmentDisposable();
-#if !NO_HASHSET
                 _shortTermWork.Add(d);
-#else
-                _shortTermWork.Add(d, null);
-#endif
 
                 //
                 // We normalize the time delta again (possibly redundant), because we can't assume
@@ -386,12 +378,10 @@ namespace System.Reactive.Concurrency
                     // is used to notice race conditions between cancellation and the timer firing (also
                     // guarded by the same gate object). See checks in ExecuteNextShortTermWorkItem.
                     //
-#if !NO_HASHSET
                     foreach (var d in _shortTermWork)
-#else
-                    foreach (var d in _shortTermWork.Keys)
-#endif
+                    {
                         d.Dispose();
+                    }
 
                     _shortTermWork.Clear();
 

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/ThreadPoolScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/ThreadPoolScheduler.cs
@@ -295,11 +295,7 @@ namespace System.Reactive.Concurrency
             //
             // Note: the dictionary exists to "root" the timers so that they are not garbage collected and finalized while they are running.
             //
-#if !NO_HASHSET
             protected static readonly HashSet<System.Threading.Timer> s_timers = new HashSet<System.Threading.Timer>();
-#else
-            protected static readonly Dictionary<System.Threading.Timer, object> s_timers = new Dictionary<System.Threading.Timer, object>();
-#endif
         }
 
         sealed class Timer<TState> : Timer, IDisposable
@@ -330,11 +326,7 @@ namespace System.Reactive.Concurrency
                 {
                     if (!_hasRemoved)
                     {
-#if !NO_HASHSET
                         s_timers.Add(_timer);
-#else
-                        s_timers.Add(_timer, null);
-#endif
 
                         _hasAdded = true;
                     }
@@ -393,11 +385,7 @@ namespace System.Reactive.Concurrency
             //
             // Note: the dictionary exists to "root" the timers so that they are not garbage collected and finalized while they are running.
             //
-#if !NO_HASHSET
             protected static readonly HashSet<System.Threading.Timer> s_timers = new HashSet<System.Threading.Timer>();
-#else
-            protected static readonly Dictionary<System.Threading.Timer, object> s_timers = new Dictionary<System.Threading.Timer, object>();
-#endif
         }
 
         sealed class PeriodicTimer<TState> : PeriodicTimer, IDisposable
@@ -418,11 +406,7 @@ namespace System.Reactive.Concurrency
 
                 lock (s_timers)
                 {
-#if !NO_HASHSET
                     s_timers.Add(_timer);
-#else
-                    s_timers.Add(_timer, null);
-#endif
                 }
             }
 


### PR DESCRIPTION
All target platforms have `HashSet<T>` now.