### PR TITLE
Removing checks for absence of SynchronizationContext

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Concurrency/Synchronization.ObserveOn.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/Synchronization.ObserveOn.cs
@@ -14,6 +14,7 @@ namespace System.Reactive.Concurrency
     {
         private readonly IObservable<TSource> _source;
         private readonly IScheduler _scheduler;
+        private readonly SynchronizationContext _context;
 
         public ObserveOn(IObservable<TSource> source, IScheduler scheduler)
         {
@@ -21,20 +22,15 @@ namespace System.Reactive.Concurrency
             _scheduler = scheduler;
         }
 
-#if !NO_SYNCCTX
-        private readonly SynchronizationContext _context;
-
         public ObserveOn(IObservable<TSource> source, SynchronizationContext context)
         {
             _source = source;
             _context = context;
         }
-#endif
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1062:Validate arguments of public methods", MessageId = "2", Justification = "Visibility restricted to friend assemblies. Those should be correct by inspection.")]
         protected override IDisposable Run(IObserver<TSource> observer, IDisposable cancel, Action<IDisposable> setSink)
         {
-#if !NO_SYNCCTX
             if (_context != null)
             {
                 var sink = new ObserveOnSink(this, observer, cancel);
@@ -42,7 +38,6 @@ namespace System.Reactive.Concurrency
                 return sink.Run();
             }
             else
-#endif
             {
                 var sink = new ObserveOnObserver<TSource>(_scheduler, observer, cancel);
                 setSink(sink);
@@ -50,7 +45,6 @@ namespace System.Reactive.Concurrency
             }
         }
 
-#if !NO_SYNCCTX
         class ObserveOnSink : Sink<TSource>, IObserver<TSource>
         {
             private readonly ObserveOn<TSource> _parent;
@@ -113,7 +107,6 @@ namespace System.Reactive.Concurrency
                 base.Dispose();
             }
         }
-#endif
     }
 }
 #endif

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/Synchronization.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/Synchronization.cs
@@ -51,7 +51,6 @@ namespace System.Reactive.Concurrency
             });
         }
 
-#if !NO_SYNCCTX
         /// <summary>
         /// Wraps the source sequence in order to run its subscription and unsubscription logic on the specified synchronization context.
         /// </summary>
@@ -82,7 +81,6 @@ namespace System.Reactive.Concurrency
                 return subscription;
             });
         }
-#endif
 
         #endregion
 
@@ -110,7 +108,6 @@ namespace System.Reactive.Concurrency
 #endif
         }
 
-#if !NO_SYNCCTX
         /// <summary>
         /// Wraps the source sequence in order to run its observer callbacks on the specified synchronization context.
         /// </summary>
@@ -153,7 +150,6 @@ namespace System.Reactive.Concurrency
             });
 #endif
         }
-#endif
 
         #endregion
 

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/SynchronizationContextScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/SynchronizationContextScheduler.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information. 
 
-#if !NO_SYNCCTX
 using System.Reactive.Disposables;
 using System.Threading;
 
@@ -98,4 +97,3 @@ namespace System.Reactive.Concurrency
         }
     }
 }
-#endif

--- a/Rx.NET/Source/src/System.Reactive/Disposables/ContextDisposable.cs
+++ b/Rx.NET/Source/src/System.Reactive/Disposables/ContextDisposable.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information. 
 
-#if !NO_SYNCCTX
 using System.Reactive.Concurrency;
 using System.Threading;
 
@@ -63,4 +62,3 @@ namespace System.Reactive.Disposables
         }
     }
 }
-#endif

--- a/Rx.NET/Source/src/System.Reactive/Internal/SynchronizationContextExtensions.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/SynchronizationContextExtensions.cs
@@ -2,7 +2,6 @@
 // The .NET Foundation licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information. 
 
-#if !NO_SYNCCTX
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -54,4 +53,3 @@ namespace System.Reactive.Concurrency
         }
     }
 }
-#endif

--- a/Rx.NET/Source/src/System.Reactive/Linq/IQueryLanguage.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/IQueryLanguage.cs
@@ -380,13 +380,11 @@ namespace System.Reactive.Linq
         #region * Concurrency *
 
         IObservable<TSource> ObserveOn<TSource>(IObservable<TSource> source, IScheduler scheduler);
-#if !NO_SYNCCTX
         IObservable<TSource> ObserveOn<TSource>(IObservable<TSource> source, SynchronizationContext context);
-#endif
+
         IObservable<TSource> SubscribeOn<TSource>(IObservable<TSource> source, IScheduler scheduler);
-#if !NO_SYNCCTX
         IObservable<TSource> SubscribeOn<TSource>(IObservable<TSource> source, SynchronizationContext context);
-#endif
+
         IObservable<TSource> Synchronize<TSource>(IObservable<TSource> source);
         IObservable<TSource> Synchronize<TSource>(IObservable<TSource> source, object gate);
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable.Concurrency.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable.Concurrency.cs
@@ -33,7 +33,6 @@ namespace System.Reactive.Linq
             return s_impl.ObserveOn<TSource>(source, scheduler);
         }
 
-#if !NO_SYNCCTX
         /// <summary>
         /// Wraps the source sequence in order to run its observer callbacks on the specified synchronization context.
         /// </summary>
@@ -55,7 +54,6 @@ namespace System.Reactive.Linq
 
             return s_impl.ObserveOn<TSource>(source, context);
         }
-#endif
 
         #endregion
 
@@ -84,7 +82,6 @@ namespace System.Reactive.Linq
             return s_impl.SubscribeOn<TSource>(source, scheduler);
         }
 
-#if !NO_SYNCCTX
         /// <summary>
         /// Wraps the source sequence in order to run its subscription and unsubscription logic on the specified synchronization context. This operation is not commonly used;
         /// see the remarks section for more information on the distinction between SubscribeOn and ObserveOn.
@@ -107,7 +104,6 @@ namespace System.Reactive.Linq
 
             return s_impl.SubscribeOn<TSource>(source, context);
         }
-#endif
 
         #endregion
 

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/ObserveOn.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/ObserveOn.cs
@@ -13,6 +13,7 @@ namespace System.Reactive.Linq.ObservableImpl
     {
         private readonly IObservable<TSource> _source;
         private readonly IScheduler _scheduler;
+        private readonly SynchronizationContext _context;
 
         public ObserveOn(IObservable<TSource> source, IScheduler scheduler)
         {
@@ -20,19 +21,14 @@ namespace System.Reactive.Linq.ObservableImpl
             _scheduler = scheduler;
         }
 
-#if !NO_SYNCCTX
-        private readonly SynchronizationContext _context;
-
         public ObserveOn(IObservable<TSource> source, SynchronizationContext context)
         {
             _source = source;
             _context = context;
         }
-#endif
 
         protected override IDisposable Run(IObserver<TSource> observer, IDisposable cancel, Action<IDisposable> setSink)
         {
-#if !NO_SYNCCTX
             if (_context != null)
             {
                 var sink = new ObserveOnImpl(this, observer, cancel);
@@ -40,7 +36,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 return _source.Subscribe(sink);
             }
             else
-#endif
             {
                 var sink = new ObserveOnObserver<TSource>(_scheduler, observer, cancel);
                 setSink(sink);
@@ -48,7 +43,6 @@ namespace System.Reactive.Linq.ObservableImpl
             }
         }
 
-#if !NO_SYNCCTX
         class ObserveOnImpl : Sink<TSource>, IObserver<TSource>
         {
             private readonly ObserveOn<TSource> _parent;
@@ -85,7 +79,6 @@ namespace System.Reactive.Linq.ObservableImpl
                 });
             }
         }
-#endif
     }
 }
 #endif

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Concurrency.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Concurrency.cs
@@ -21,12 +21,10 @@ namespace System.Reactive.Linq
             return Synchronization.ObserveOn<TSource>(source, scheduler);
         }
 
-#if !NO_SYNCCTX
         public virtual IObservable<TSource> ObserveOn<TSource>(IObservable<TSource> source, SynchronizationContext context)
         {
             return Synchronization.ObserveOn<TSource>(source, context);
         }
-#endif
 
         #endregion
 
@@ -37,12 +35,10 @@ namespace System.Reactive.Linq
             return Synchronization.SubscribeOn<TSource>(source, scheduler);
         }
 
-#if !NO_SYNCCTX
         public virtual IObservable<TSource> SubscribeOn<TSource>(IObservable<TSource> source, SynchronizationContext context)
         {
             return Synchronization.SubscribeOn<TSource>(source, context);
         }
-#endif
 
         #endregion
 

--- a/Rx.NET/Source/src/System.Reactive/Observer.Extensions.cs
+++ b/Rx.NET/Source/src/System.Reactive/Observer.Extensions.cs
@@ -258,7 +258,6 @@ namespace System.Reactive
             return new ObserveOnObserver<T>(scheduler, observer, null);
         }
 
-#if !NO_SYNCCTX
         /// <summary>
         /// Schedules the invocation of observer methods on the given synchonization context.
         /// </summary>
@@ -276,8 +275,7 @@ namespace System.Reactive
 
             return new ObserveOnObserver<T>(new SynchronizationContextScheduler(context), observer, null);
         }
-#endif
-        
+
         /// <summary>
         /// Converts an observer to a progress object.
         /// </summary>


### PR DESCRIPTION
Every targeted platform has `SynchronizationContext` so we no longer need to `#if` check for it.