### PR TITLE
Using nameof when looking up members through reflection

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Joins/QueryablePattern.cs
+++ b/Rx.NET/Source/src/System.Reactive/Joins/QueryablePattern.cs
@@ -58,7 +58,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(other));
 
             var t = typeof(QueryablePattern<TSource1, TSource2>);
-            var m = t.GetMethod("And").MakeGenericMethod(typeof(TSource3));
+            var m = t.GetMethod(nameof(And)).MakeGenericMethod(typeof(TSource3));
             return new QueryablePattern<TSource1, TSource2, TSource3>(
                 Expression.Call(
                     Expression,
@@ -82,7 +82,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(selector));
 
             var t = typeof(QueryablePattern<TSource1, TSource2>);
-            var m = t.GetMethod("Then").MakeGenericMethod(typeof(TResult));
+            var m = t.GetMethod(nameof(Then)).MakeGenericMethod(typeof(TResult));
             return new QueryablePlan<TResult>(
                 Expression.Call(
                     Expression,
@@ -121,7 +121,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(other));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3>);
-            var m = t.GetMethod("And").MakeGenericMethod(typeof(TSource4));
+            var m = t.GetMethod(nameof(And)).MakeGenericMethod(typeof(TSource4));
             return new QueryablePattern<TSource1, TSource2, TSource3, TSource4>(
                 Expression.Call(
                     Expression,
@@ -145,7 +145,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(selector));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3>);
-            var m = t.GetMethod("Then").MakeGenericMethod(typeof(TResult));
+            var m = t.GetMethod(nameof(Then)).MakeGenericMethod(typeof(TResult));
             return new QueryablePlan<TResult>(
                 Expression.Call(
                     Expression,
@@ -186,7 +186,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(other));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4>);
-            var m = t.GetMethod("And").MakeGenericMethod(typeof(TSource5));
+            var m = t.GetMethod(nameof(And)).MakeGenericMethod(typeof(TSource5));
             return new QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5>(
                 Expression.Call(
                     Expression,
@@ -211,7 +211,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(selector));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4>);
-            var m = t.GetMethod("Then").MakeGenericMethod(typeof(TResult));
+            var m = t.GetMethod(nameof(Then)).MakeGenericMethod(typeof(TResult));
             return new QueryablePlan<TResult>(
                 Expression.Call(
                     Expression,
@@ -253,7 +253,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(other));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5>);
-            var m = t.GetMethod("And").MakeGenericMethod(typeof(TSource6));
+            var m = t.GetMethod(nameof(And)).MakeGenericMethod(typeof(TSource6));
             return new QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6>(
                 Expression.Call(
                     Expression,
@@ -277,7 +277,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(selector));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5>);
-            var m = t.GetMethod("Then").MakeGenericMethod(typeof(TResult));
+            var m = t.GetMethod(nameof(Then)).MakeGenericMethod(typeof(TResult));
             return new QueryablePlan<TResult>(
                 Expression.Call(
                     Expression,
@@ -319,7 +319,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(other));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6>);
-            var m = t.GetMethod("And").MakeGenericMethod(typeof(TSource7));
+            var m = t.GetMethod(nameof(And)).MakeGenericMethod(typeof(TSource7));
             return new QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7>(
                 Expression.Call(
                     Expression,
@@ -343,7 +343,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(selector));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6>);
-            var m = t.GetMethod("Then").MakeGenericMethod(typeof(TResult));
+            var m = t.GetMethod(nameof(Then)).MakeGenericMethod(typeof(TResult));
             return new QueryablePlan<TResult>(
                 Expression.Call(
                     Expression,
@@ -386,7 +386,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(other));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7>);
-            var m = t.GetMethod("And").MakeGenericMethod(typeof(TSource8));
+            var m = t.GetMethod(nameof(And)).MakeGenericMethod(typeof(TSource8));
             return new QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8>(
                 Expression.Call(
                     Expression,
@@ -410,7 +410,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(selector));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7>);
-            var m = t.GetMethod("Then").MakeGenericMethod(typeof(TResult));
+            var m = t.GetMethod(nameof(Then)).MakeGenericMethod(typeof(TResult));
             return new QueryablePlan<TResult>(
                 Expression.Call(
                     Expression,
@@ -454,7 +454,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(other));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8>);
-            var m = t.GetMethod("And").MakeGenericMethod(typeof(TSource9));
+            var m = t.GetMethod(nameof(And)).MakeGenericMethod(typeof(TSource9));
             return new QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9>(
                 Expression.Call(
                     Expression,
@@ -478,7 +478,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(selector));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8>);
-            var m = t.GetMethod("Then").MakeGenericMethod(typeof(TResult));
+            var m = t.GetMethod(nameof(Then)).MakeGenericMethod(typeof(TResult));
             return new QueryablePlan<TResult>(
                 Expression.Call(
                     Expression,
@@ -523,7 +523,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(other));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9>);
-            var m = t.GetMethod("And").MakeGenericMethod(typeof(TSource10));
+            var m = t.GetMethod(nameof(And)).MakeGenericMethod(typeof(TSource10));
             return new QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10>(
                 Expression.Call(
                     Expression,
@@ -547,7 +547,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(selector));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9>);
-            var m = t.GetMethod("Then").MakeGenericMethod(typeof(TResult));
+            var m = t.GetMethod(nameof(Then)).MakeGenericMethod(typeof(TResult));
             return new QueryablePlan<TResult>(
                 Expression.Call(
                     Expression,
@@ -593,7 +593,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(other));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10>);
-            var m = t.GetMethod("And").MakeGenericMethod(typeof(TSource11));
+            var m = t.GetMethod(nameof(And)).MakeGenericMethod(typeof(TSource11));
             return new QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11>(
                 Expression.Call(
                     Expression,
@@ -617,7 +617,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(selector));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10>);
-            var m = t.GetMethod("Then").MakeGenericMethod(typeof(TResult));
+            var m = t.GetMethod(nameof(Then)).MakeGenericMethod(typeof(TResult));
             return new QueryablePlan<TResult>(
                 Expression.Call(
                     Expression,
@@ -664,7 +664,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(other));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11>);
-            var m = t.GetMethod("And").MakeGenericMethod(typeof(TSource12));
+            var m = t.GetMethod(nameof(And)).MakeGenericMethod(typeof(TSource12));
             return new QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12>(
                 Expression.Call(
                     Expression,
@@ -688,7 +688,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(selector));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11>);
-            var m = t.GetMethod("Then").MakeGenericMethod(typeof(TResult));
+            var m = t.GetMethod(nameof(Then)).MakeGenericMethod(typeof(TResult));
             return new QueryablePlan<TResult>(
                 Expression.Call(
                     Expression,
@@ -736,7 +736,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(other));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12>);
-            var m = t.GetMethod("And").MakeGenericMethod(typeof(TSource13));
+            var m = t.GetMethod(nameof(And)).MakeGenericMethod(typeof(TSource13));
             return new QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13>(
                 Expression.Call(
                     Expression,
@@ -760,7 +760,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(selector));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12>);
-            var m = t.GetMethod("Then").MakeGenericMethod(typeof(TResult));
+            var m = t.GetMethod(nameof(Then)).MakeGenericMethod(typeof(TResult));
             return new QueryablePlan<TResult>(
                 Expression.Call(
                     Expression,
@@ -809,7 +809,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(other));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13>);
-            var m = t.GetMethod("And").MakeGenericMethod(typeof(TSource14));
+            var m = t.GetMethod(nameof(And)).MakeGenericMethod(typeof(TSource14));
             return new QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14>(
                 Expression.Call(
                     Expression,
@@ -833,7 +833,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(selector));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13>);
-            var m = t.GetMethod("Then").MakeGenericMethod(typeof(TResult));
+            var m = t.GetMethod(nameof(Then)).MakeGenericMethod(typeof(TResult));
             return new QueryablePlan<TResult>(
                 Expression.Call(
                     Expression,
@@ -883,7 +883,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(other));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14>);
-            var m = t.GetMethod("And").MakeGenericMethod(typeof(TSource15));
+            var m = t.GetMethod(nameof(And)).MakeGenericMethod(typeof(TSource15));
             return new QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15>(
                 Expression.Call(
                     Expression,
@@ -907,7 +907,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(selector));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14>);
-            var m = t.GetMethod("Then").MakeGenericMethod(typeof(TResult));
+            var m = t.GetMethod(nameof(Then)).MakeGenericMethod(typeof(TResult));
             return new QueryablePlan<TResult>(
                 Expression.Call(
                     Expression,
@@ -958,7 +958,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(other));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15>);
-            var m = t.GetMethod("And").MakeGenericMethod(typeof(TSource16));
+            var m = t.GetMethod(nameof(And)).MakeGenericMethod(typeof(TSource16));
             return new QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, TSource16>(
                 Expression.Call(
                     Expression,
@@ -982,7 +982,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(selector));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15>);
-            var m = t.GetMethod("Then").MakeGenericMethod(typeof(TResult));
+            var m = t.GetMethod(nameof(Then)).MakeGenericMethod(typeof(TResult));
             return new QueryablePlan<TResult>(
                 Expression.Call(
                     Expression,
@@ -1034,7 +1034,7 @@ namespace System.Reactive.Joins
                 throw new ArgumentNullException(nameof(selector));
 
             var t = typeof(QueryablePattern<TSource1, TSource2, TSource3, TSource4, TSource5, TSource6, TSource7, TSource8, TSource9, TSource10, TSource11, TSource12, TSource13, TSource14, TSource15, TSource16>);
-            var m = t.GetMethod("Then").MakeGenericMethod(typeof(TResult));
+            var m = t.GetMethod(nameof(Then)).MakeGenericMethod(typeof(TResult));
             return new QueryablePlan<TResult>(
                 Expression.Call(
                     Expression,

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/FromEvent.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/FromEvent.cs
@@ -181,7 +181,7 @@ namespace System.Reactive.Linq.ObservableImpl
 
             if (_conversion == null)
             {
-                handler = ReflectionUtils.CreateDelegate<TDelegate>(onNext, typeof(Action<TEventArgs>).GetMethod("Invoke"));
+                handler = ReflectionUtils.CreateDelegate<TDelegate>(onNext, typeof(Action<TEventArgs>).GetMethod(nameof(Action<TEventArgs>.Invoke)));
             }
             else
             {

--- a/Rx.NET/Source/src/System.Reactive/Linq/Observable/FromEventPattern.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/Observable/FromEventPattern.cs
@@ -40,7 +40,7 @@ namespace System.Reactive.Linq.ObservableImpl
                 if (_conversion == null)
                 {
                     Action<object, TEventArgs> h = (sender, eventArgs) => onNext(new EventPattern<TEventArgs>(sender, eventArgs));
-                    handler = ReflectionUtils.CreateDelegate<TDelegate>(h, typeof(Action<object, TEventArgs>).GetMethod("Invoke"));
+                    handler = ReflectionUtils.CreateDelegate<TDelegate>(h, typeof(Action<object, TEventArgs>).GetMethod(nameof(Action<object, TEventArgs>.Invoke)));
                 }
                 else
                 {
@@ -61,7 +61,7 @@ namespace System.Reactive.Linq.ObservableImpl
             protected override TDelegate GetHandler(Action<EventPattern<TSender, TEventArgs>> onNext)
             {
                 Action<TSender, TEventArgs> h = (sender, eventArgs) => onNext(new EventPattern<TSender, TEventArgs>(sender, eventArgs));
-                return ReflectionUtils.CreateDelegate<TDelegate>(h, typeof(Action<TSender, TEventArgs>).GetMethod("Invoke"));
+                return ReflectionUtils.CreateDelegate<TDelegate>(h, typeof(Action<TSender, TEventArgs>).GetMethod(nameof(Action<TSender, TEventArgs>.Invoke)));
             }
         }
 
@@ -94,7 +94,7 @@ namespace System.Reactive.Linq.ObservableImpl
             protected override Delegate GetHandler(Action<TResult> onNext)
             {
                 Action<TSender, TEventArgs> h = (sender, eventArgs) => onNext(_getResult(sender, eventArgs));
-                return ReflectionUtils.CreateDelegate(_delegateType, h, typeof(Action<TSender, TEventArgs>).GetMethod("Invoke"));
+                return ReflectionUtils.CreateDelegate(_delegateType, h, typeof(Action<TSender, TEventArgs>).GetMethod(nameof(Action<TSender, TEventArgs>.Invoke)));
             }
 
             protected override IDisposable AddHandler(Delegate handler)

--- a/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Events.cs
+++ b/Rx.NET/Source/src/System.Reactive/Linq/QueryLanguage.Events.cs
@@ -79,7 +79,7 @@ namespace System.Reactive.Linq
             var res = new AnonymousObservable<EventPattern<TEventArgs>>(observer =>
             {
                 Action<object, TEventArgs> handler = (sender, eventArgs) => observer.OnNext(new EventPattern<TEventArgs>(sender, eventArgs));
-                var d = ReflectionUtils.CreateDelegate<TDelegate>(handler, typeof(Action<object, TEventArgs>).GetMethod("Invoke"));
+                var d = ReflectionUtils.CreateDelegate<TDelegate>(handler, typeof(Action<object, TEventArgs>).GetMethod(nameof(Action<object, TEventArgs>.Invoke)));
                 addHandler(d);
                 return Disposable.Create(() => removeHandler(d));
             });
@@ -140,7 +140,7 @@ namespace System.Reactive.Linq
             var res = new AnonymousObservable<EventPattern<TSender, TEventArgs>>(observer =>
             {
                 Action<TSender, TEventArgs> handler = (sender, eventArgs) => observer.OnNext(new EventPattern<TSender, TEventArgs>(sender, eventArgs));
-                var d = ReflectionUtils.CreateDelegate<TDelegate>(handler, typeof(Action<TSender, TEventArgs>).GetMethod("Invoke"));
+                var d = ReflectionUtils.CreateDelegate<TDelegate>(handler, typeof(Action<TSender, TEventArgs>).GetMethod(nameof(Action<TSender, TEventArgs>.Invoke)));
                 addHandler(d);
                 return Disposable.Create(() => removeHandler(d));
             });
@@ -326,7 +326,7 @@ namespace System.Reactive.Linq
                 return new AnonymousObservable<TResult>(observer =>
                 {
                     Action<TSender, TEventArgs> handler = (sender, eventArgs) => observer.OnNext(getResult(sender, eventArgs));
-                    var d = ReflectionUtils.CreateDelegate(delegateType, handler, typeof(Action<TSender, TEventArgs>).GetMethod("Invoke"));
+                    var d = ReflectionUtils.CreateDelegate(delegateType, handler, typeof(Action<TSender, TEventArgs>).GetMethod(nameof(Action<TSender, TEventArgs>.Invoke)));
                     var token = addMethod.Invoke(target, new object[] { d });
                     return Disposable.Create(() => removeMethod.Invoke(target, new object[] { token }));
                 });
@@ -340,7 +340,7 @@ namespace System.Reactive.Linq
             var res = new AnonymousObservable<TResult>(observer =>
             {
                 Action<TSender, TEventArgs> handler = (sender, eventArgs) => observer.OnNext(getResult(sender, eventArgs));
-                var d = ReflectionUtils.CreateDelegate(delegateType, handler, typeof(Action<TSender, TEventArgs>).GetMethod("Invoke"));
+                var d = ReflectionUtils.CreateDelegate(delegateType, handler, typeof(Action<TSender, TEventArgs>).GetMethod(nameof(Action<TSender, TEventArgs>.Invoke)));
                 addMethod.Invoke(target, new object[] { d });
                 return Disposable.Create(() => removeMethod.Invoke(target, new object[] { d }));
             });
@@ -407,7 +407,7 @@ namespace System.Reactive.Linq
             var res = new AnonymousObservable<TEventArgs>(observer =>
             {
                 Action<TEventArgs> handler = observer.OnNext;
-                var d = ReflectionUtils.CreateDelegate<TDelegate>(handler, typeof(Action<TEventArgs>).GetMethod("Invoke"));
+                var d = ReflectionUtils.CreateDelegate<TDelegate>(handler, typeof(Action<TEventArgs>).GetMethod(nameof(Action<TEventArgs>.Invoke)));
                 addHandler(d);
                 return Disposable.Create(() => removeHandler(d));
             });

--- a/Rx.NET/Source/src/System.Reactive/ObservableQuery.cs
+++ b/Rx.NET/Source/src/System.Reactive/ObservableQuery.cs
@@ -38,7 +38,7 @@ namespace System.Reactive
             //   observable.AsQbservable().<operators>.ToEnumerable().AsQueryable()
             //
             var call = expression as MethodCallExpression;
-            if (call == null || call.Method.DeclaringType != typeof(Qbservable) || call.Method.Name != "ToQueryable")
+            if (call == null || call.Method.DeclaringType != typeof(Qbservable) || call.Method.Name != nameof(Qbservable.ToQueryable))
                 throw new ArgumentException(Strings_Providers.EXPECTED_TOQUERYABLE_METHODCALL, nameof(expression));
 
             //
@@ -50,7 +50,7 @@ namespace System.Reactive
                 Expression.Call(
                     AsQueryable.MakeGenericMethod(typeof(TElement)),
                     Expression.Call(
-                        typeof(Observable).GetMethod("ToEnumerable").MakeGenericMethod(typeof(TElement)),
+                        typeof(Observable).GetMethod(nameof(Observable.ToEnumerable)).MakeGenericMethod(typeof(TElement)),
                         arg0
                     )
                 );

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Concurrency/AsyncLockTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/Concurrency/AsyncLockTest.cs
@@ -111,7 +111,7 @@ namespace ReactiveTests.Tests
             {
                 try
                 {
-                    instance.GetType().GetMethod("Wait").Invoke(instance, new object[] { action });
+                    instance.GetType().GetMethod(nameof(AsyncLock.Wait)).Invoke(instance, new object[] { action });
                 }
                 catch (TargetInvocationException ex)
                 {
@@ -123,7 +123,7 @@ namespace ReactiveTests.Tests
             {
                 try
                 {
-                    instance.GetType().GetMethod("Dispose").Invoke(instance, new object[0]);
+                    instance.GetType().GetMethod(nameof(AsyncLock.Dispose)).Invoke(instance, new object[0]);
                 }
                 catch (TargetInvocationException ex)
                 {

--- a/Rx.NET/Source/tests/Tests.System.Reactive/Tests/PrivateTypesTest.cs
+++ b/Rx.NET/Source/tests/Tests.System.Reactive/Tests/PrivateTypesTest.cs
@@ -155,12 +155,12 @@ namespace ReactiveTests.Tests
 
         public override int GetHashCode()
         {
-            return (int)_value.GetType().GetMethod("GetHashCode").Invoke(_value, null);
+            return (int)_value.GetType().GetMethod(nameof(GetHashCode)).Invoke(_value, null);
         }
 
         public override string ToString()
         {
-            return (string)_value.GetType().GetMethod("ToString").Invoke(_value, null);
+            return (string)_value.GetType().GetMethod(nameof(ToString)).Invoke(_value, null);
         }
     }
 
@@ -169,7 +169,7 @@ namespace ReactiveTests.Tests
         public static Either<TLeft, TRight> CreateLeft(TLeft value)
         {
             var tpe = typeof(Observable).GetTypeInfo().Assembly.GetTypes().Single(t => t.Name == "Either`2").MakeGenericType(typeof(TLeft), typeof(TRight));
-            var mth = tpe.GetMethod("CreateLeft");
+            var mth = tpe.GetMethod(nameof(CreateLeft));
             var res = mth.Invoke(null, new object[] { value });
             return new Either<TLeft, TRight>.Left(res);
         }
@@ -177,20 +177,20 @@ namespace ReactiveTests.Tests
         public static Either<TLeft, TRight> CreateRight(TRight value)
         {
             var tpe = typeof(Observable).GetTypeInfo().Assembly.GetTypes().Single(t => t.Name == "Either`2").MakeGenericType(typeof(TLeft), typeof(TRight));
-            var mth = tpe.GetMethod("CreateRight");
+            var mth = tpe.GetMethod(nameof(CreateRight));
             var res = mth.Invoke(null, new object[] { value });
             return new Either<TLeft, TRight>.Right(res);
         }
 
         public TResult Switch<TResult>(Func<TLeft, TResult> caseLeft, Func<TRight, TResult> caseRight)
         {
-            var mth = _value.GetType().GetMethods().Where(m => m.Name == "Switch" && m.ReturnType != typeof(void)).Single().MakeGenericMethod(typeof(TResult));
+            var mth = _value.GetType().GetMethods().Where(m => m.Name == nameof(Switch) && m.ReturnType != typeof(void)).Single().MakeGenericMethod(typeof(TResult));
             return (TResult)mth.Invoke(_value, new object[] { caseLeft, caseRight });
         }
 
         public void Switch(Action<TLeft> caseLeft, Action<TRight> caseRight)
         {
-            var mth = _value.GetType().GetMethods().Where(m => m.Name == "Switch" && m.ReturnType == typeof(void)).Single();
+            var mth = _value.GetType().GetMethods().Where(m => m.Name == nameof(Switch) && m.ReturnType == typeof(void)).Single();
             mth.Invoke(_value, new object[] { caseLeft, caseRight });
         }
 
@@ -200,7 +200,7 @@ namespace ReactiveTests.Tests
             {
                 get
                 {
-                    return (TLeft)_value.GetType().GetProperty("Value").GetValue(_value, null);
+                    return (TLeft)_value.GetType().GetProperty(nameof(Value)).GetValue(_value, null);
                 }
             }
 
@@ -211,7 +211,7 @@ namespace ReactiveTests.Tests
 
             public bool Equals(Left other)
             {
-                var equ = _value.GetType().GetMethods().Where(m => m.Name == "Equals" && m.GetParameters()[0].ParameterType != typeof(object)).Single();
+                var equ = _value.GetType().GetMethods().Where(m => m.Name == nameof(Equals) && m.GetParameters()[0].ParameterType != typeof(object)).Single();
                 return (bool)equ.Invoke(_value, new object[] { other == null ? null : other._value });
             }
         }
@@ -222,7 +222,7 @@ namespace ReactiveTests.Tests
             {
                 get
                 {
-                    return (TRight)_value.GetType().GetProperty("Value").GetValue(_value, null);
+                    return (TRight)_value.GetType().GetProperty(nameof(Value)).GetValue(_value, null);
                 }
             }
 
@@ -233,7 +233,7 @@ namespace ReactiveTests.Tests
 
             public bool Equals(Right other)
             {
-                var equ = _value.GetType().GetMethods().Where(m => m.Name == "Equals" && m.GetParameters()[0].ParameterType != typeof(object)).Single();
+                var equ = _value.GetType().GetMethods().Where(m => m.Name == nameof(Equals) && m.GetParameters()[0].ParameterType != typeof(object)).Single();
                 return (bool)equ.Invoke(_value, new object[] { other == null ? null : other._value });
             }
         }


### PR DESCRIPTION
More places where use of `nameof` is applicable.