### PR TITLE
Removing conditional use of ConditionalWeakTable

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Concurrency/CatchScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/CatchScheduler.cs
@@ -3,10 +3,7 @@
 // See the LICENSE file in the project root for more information. 
 
 using System.Reactive.Disposables;
-
-#if !NO_WEAKTABLE
 using System.Runtime.CompilerServices;
-#endif
 
 namespace System.Reactive.Concurrency
 {
@@ -39,7 +36,6 @@ namespace System.Reactive.Concurrency
             };
         }
 
-#if !NO_WEAKTABLE
         public CatchScheduler(IScheduler scheduler, Func<TException, bool> handler, ConditionalWeakTable<IScheduler, IScheduler> cache)
             : base(scheduler, cache)
         {
@@ -50,12 +46,6 @@ namespace System.Reactive.Concurrency
         {
             return new CatchScheduler<TException>(scheduler, _handler, cache);
         }
-#else
-        protected override SchedulerWrapper Clone(IScheduler scheduler)
-        {
-            return new CatchScheduler<TException>(scheduler, _handler);
-        }
-#endif
 
         protected override bool TryGetService(IServiceProvider provider, Type serviceType, out object service)
         {

--- a/Rx.NET/Source/src/System.Reactive/Concurrency/DisableOptimizationsScheduler.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/DisableOptimizationsScheduler.cs
@@ -3,10 +3,7 @@
 // See the LICENSE file in the project root for more information. 
 
 using System.Linq;
-
-#if !NO_WEAKTABLE
 using System.Runtime.CompilerServices;
-#endif
 
 namespace System.Reactive.Concurrency
 {
@@ -26,7 +23,6 @@ namespace System.Reactive.Concurrency
             _optimizationInterfaces = optimizationInterfaces;
         }
 
-#if !NO_WEAKTABLE
         public DisableOptimizationsScheduler(IScheduler scheduler, Type[] optimizationInterfaces, ConditionalWeakTable<IScheduler, IScheduler> cache)
             : base(scheduler, cache)
         {
@@ -37,12 +33,6 @@ namespace System.Reactive.Concurrency
         {
             return new DisableOptimizationsScheduler(scheduler, _optimizationInterfaces, cache);
         }
-#else
-        protected override SchedulerWrapper Clone(IScheduler scheduler)
-        {
-            return new DisableOptimizationsScheduler(scheduler, _optimizationInterfaces);
-        }
-#endif
 
         protected override bool TryGetService(IServiceProvider provider, Type serviceType, out object service)
         {


### PR DESCRIPTION
`ConditionalWeakTable<,>` is available on all platforms, so we can do away with the conditional compilation.