### PR TITLE
use SourceLink.Create.CommandLine

### DIFF
--- a/Rx.NET/Source/Directory.build.props
+++ b/Rx.NET/Source/Directory.build.props
@@ -20,7 +20,6 @@
     <IncludeSymbols>false</IncludeSymbols>
     <IsTestProject>$(MSBuildProjectName.Contains('Test'))</IsTestProject>
     <GetVersion Condition=" '$(NCrunch)' != '' ">false</GetVersion>
-    <!--<SourceLinkEnabled>false</SourceLinkEnabled>-->
   </PropertyGroup>
   
   <ItemGroup>

--- a/Rx.NET/Source/Directory.build.props
+++ b/Rx.NET/Source/Directory.build.props
@@ -20,7 +20,7 @@
     <IncludeSymbols>false</IncludeSymbols>
     <IsTestProject>$(MSBuildProjectName.Contains('Test'))</IsTestProject>
     <GetVersion Condition=" '$(NCrunch)' != '' ">false</GetVersion>
-    <SourceLinkEnabled>false</SourceLinkEnabled>
+    <!--<SourceLinkEnabled>false</SourceLinkEnabled>-->
   </PropertyGroup>
   
   <ItemGroup>
@@ -29,8 +29,7 @@
   </ItemGroup>
   
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false'">
-    <PackageReference Include="SourceLink.Create.GitHub" Version="2.1.0" PrivateAssets="All" /> 
-    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.1.0" />
+    <PackageReference Include="SourceLink.Create.CommandLine" Version="2.1.0" PrivateAssets="All" /> 
   </ItemGroup>
   
   <!-- Workaround -->


### PR DESCRIPTION
This enables SourceLink again, but uses `SourceLink.Create.CommandLine` which is new to 2.1. It simply uses the git command line and not dotnet.

![image](https://cloud.githubusercontent.com/assets/80104/25263207/748a6596-2623-11e7-882b-e7d8a1140cd0.png)

I downloaded the nupkg and validated that it works:
https://ci.appveyor.com/project/ctaggart/rx-net/build/4.0.0-develop-test.319.build.18
```
dotnet sourcelink test C:\Users\CameronTaggart\Downloads\System.Reactive.4.0.0-develop-test.319.nupkg
sourcelink test passed: lib/netstandard1.3/System.Reactive.dll
sourcelink test passed: lib/net45/System.Reactive.dll
sourcelink test passed: lib/net46/System.Reactive.dll
sourcelink test passed: lib/uap10.0/System.Reactive.dll
```