### PR TITLE
Switch to use Nerdbank.Gitversioning

### DIFF
--- a/Ix.NET/Source/Directory.build.props
+++ b/Ix.NET/Source/Directory.build.props
@@ -6,7 +6,6 @@
     <MinClientVersion>2.12</MinClientVersion>
     <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
     <Authors>.NET Foundation and Contributors</Authors>
-    <UseFullSemVerForNuGet>true</UseFullSemVerForNuGet>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkId=261274</PackageIconUrl>
     <PackageProjectUrl>http://go.microsoft.com/fwlink/?LinkId=261273</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/Reactive-Extensions/Rx.NET/master/Ix.NET/Source/license.txt</PackageLicenseUrl>
@@ -15,16 +14,9 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)ReactiveX.snk</AssemblyOriginatorKeyFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <DefaultLanguage>en-US</DefaultLanguage>
-    <WriteVersionInfoToBuildLog>false</WriteVersionInfoToBuildLog>
     <IncludeSymbols>false</IncludeSymbols>
     <IsTestProject>$(MSBuildProjectName.Contains('Test'))</IsTestProject>
-    
-    <GetVersion Condition=" '$(NCrunch)' != '' ">false</GetVersion>
   </PropertyGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="4.0.0-beta0011" PrivateAssets="All" /> 
-  </ItemGroup>
   
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(NCrunch)' == '' and '$(SourceLinkEnabled)' != 'false'">
     <PackageReference Include="SourceLink.Create.CommandLine" Version="2.1.0" PrivateAssets="All" /> 
@@ -32,17 +24,22 @@
   
     <!-- Workaround -->
   <Target Name="GetPackagingOutputs" />
-   <PropertyGroup>
-    <GitVersionTaskVersion>4.0.0-beta0011</GitVersionTaskVersion>
+  
+  <PropertyGroup>
+    <NerdbankGitVersioningVersion>2.0.3-beta-g4d80666c50</NerdbankGitVersioningVersion>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="'$(NerdbankGitVersioningVersion)'" PrivateAssets="all" />
+  </ItemGroup>
 
   <!-- https://github.com/NuGet/Home/issues/4337 -->
   <ImportGroup Condition=" '$(ExcludeRestorePackageImports)' == 'true' ">
-    <Import Project="$(UserProfile)\.nuget\packages\GitVersionTask\$(GitVersionTaskVersion)\buildMultiTargeting\GitVersionTask.targets"
-            Condition="Exists('$(UserProfile)\.nuget\packages\GitVersionTask\$(GitVersionTaskVersion)\buildMultiTargeting\GitVersionTask.targets')" />
+    <Import Project="$(UserProfile)\.nuget\packages\nerdbank.gitversioning\$(NerdbankGitVersioningVersion)\buildCrossTargeting\Nerdbank.GitVersioning.targets"
+            Condition="Exists('$(UserProfile)\.nuget\packages\nerdbank.gitversioning\$(NerdbankGitVersioningVersion)\buildCrossTargeting\Nerdbank.GitVersioning.targets')" />
   </ImportGroup>
-  <Target Name="FixupVersion"
+  <Target Name="FixUpVersion"
       BeforeTargets="_GenerateRestoreProjectSpec"
-      DependsOnTargets="GetVersion"
-      Condition=" '$(GitVersion_Task_targets_Imported)' == 'True' " />
+      DependsOnTargets="GetBuildVersion"
+      Condition=" '$(NerdbankGitVersioningTasksPath)' != '' " />
 </Project>

--- a/Ix.NET/Source/Directory.build.props
+++ b/Ix.NET/Source/Directory.build.props
@@ -30,7 +30,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="'$(NerdbankGitVersioningVersion)'" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.0.3-beta-g4d80666c50" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- https://github.com/NuGet/Home/issues/4337 -->

--- a/Ix.NET/Source/NuGet.Config
+++ b/Ix.NET/Source/NuGet.Config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <add key="xUnit CI" value="https://www.myget.org/F/xunit/api/v3/index.json" />
+    <add key="NBGV CI" value="https://ci.appveyor.com/nuget/nerdbank-gitversioning" />
     <add key="Build Packages" value="https://www.myget.org/F/c037199d-41df-4567-b966-25ff65324688/api/v3/index.json" />
     <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>

--- a/Ix.NET/Source/build-new.ps1
+++ b/Ix.NET/Source/build-new.ps1
@@ -31,7 +31,7 @@ if (!(Test-Path .\nuget.exe)) {
 .\nuget.exe install -excludeversion SignClient -Version 0.7.0 -outputdirectory packages
 .\nuget.exe install -excludeversion JetBrains.dotCover.CommandLineTools -pre -outputdirectory packages
 .\nuget.exe install -excludeversion gitversion.commandline -pre -outputdirectory packages
-.\nuget.exe install -excludeversion Nerdbank.GitVersioning -Version 1.6.27-ge56a446f19 -pre -outputdirectory packages
+.\nuget.exe install -excludeversion Nerdbank.GitVersioning -Version 2.0.3-beta-g4d80666c50 -pre -outputdirectory packages
 .\nuget.exe install -excludeversion xunit.runner.console -pre -outputdirectory packages
 .\nuget.exe install -excludeversion ReportGenerator -outputdirectory packages
 #.\nuget.exe install -excludeversion coveralls.io -outputdirectory packages

--- a/Ix.NET/Source/build-new.ps1
+++ b/Ix.NET/Source/build-new.ps1
@@ -31,6 +31,7 @@ if (!(Test-Path .\nuget.exe)) {
 .\nuget.exe install -excludeversion SignClient -Version 0.7.0 -outputdirectory packages
 .\nuget.exe install -excludeversion JetBrains.dotCover.CommandLineTools -pre -outputdirectory packages
 .\nuget.exe install -excludeversion gitversion.commandline -pre -outputdirectory packages
+.\nuget.exe install -excludeversion Nerdbank.GitVersioning -Version 1.6.27-ge56a446f19 -pre -outputdirectory packages
 .\nuget.exe install -excludeversion xunit.runner.console -pre -outputdirectory packages
 .\nuget.exe install -excludeversion ReportGenerator -outputdirectory packages
 #.\nuget.exe install -excludeversion coveralls.io -outputdirectory packages

--- a/Ix.NET/Source/build-new.ps1
+++ b/Ix.NET/Source/build-new.ps1
@@ -30,17 +30,17 @@ if (!(Test-Path .\nuget.exe)) {
 # get tools
 .\nuget.exe install -excludeversion SignClient -Version 0.7.0 -outputdirectory packages
 .\nuget.exe install -excludeversion JetBrains.dotCover.CommandLineTools -pre -outputdirectory packages
-.\nuget.exe install -excludeversion gitversion.commandline -pre -outputdirectory packages
 .\nuget.exe install -excludeversion Nerdbank.GitVersioning -Version 2.0.3-beta-g4d80666c50 -pre -outputdirectory packages
 .\nuget.exe install -excludeversion xunit.runner.console -pre -outputdirectory packages
 .\nuget.exe install -excludeversion ReportGenerator -outputdirectory packages
 #.\nuget.exe install -excludeversion coveralls.io -outputdirectory packages
 .\nuget.exe install -excludeversion coveralls.io.dotcover -outputdirectory packages
 
+#update version
+$versionObj = .\packages\Nerdbank.GitVersioning\tools\get-version.ps1
+$packageSemVer = $versionObj.NuGetPackageVersion
 
-.\packages\gitversion.commandline\tools\gitversion.exe /l console /output buildserver
-$versionObj = .\packages\gitversion.commandline\tools\gitversion.exe | ConvertFrom-Json
-$packageSemVer = $versionObj.FullSemVer
+Write-Host "Building $packageSemVer" -Foreground Green
 
 New-Item -ItemType Directory -Force -Path $artifacts
 

--- a/Ix.NET/Source/version.json
+++ b/Ix.NET/Source/version.json
@@ -1,9 +1,5 @@
 {
-  "$schema": "src\\NerdBank.GitVersioning\\version.schema.json",
-  "version": "3.2.1-alpha.{height}",
-  "assemblyVersion": {
-    "precision": "revision"
-  },
+  "version": "3.2.0-preview.{height}",
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
     "^refs/heads/develop$", // we release out of develop

--- a/Ix.NET/Source/version.json
+++ b/Ix.NET/Source/version.json
@@ -1,11 +1,12 @@
 {
   "$schema": "src\\NerdBank.GitVersioning\\version.schema.json",
-  "version": "3.2.1-alpha",
+  "version": "3.2.1-alpha.{height}",
   "assemblyVersion": {
     "precision": "revision"
   },
   "publicReleaseRefSpec": [
     "^refs/heads/master$", // we release out of master
+    "^refs/heads/develop$", // we release out of develop
     "^refs/tags/v\\d+\\.\\d+" // we also release tags starting with vN.N
   ],
   "cloudBuild": {

--- a/Ix.NET/Source/version.json
+++ b/Ix.NET/Source/version.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "src\\NerdBank.GitVersioning\\version.schema.json",
+  "version": "3.2.1-alpha",
+  "assemblyVersion": {
+    "precision": "revision"
+  },
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$", // we release out of master
+    "^refs/tags/v\\d+\\.\\d+" // we also release tags starting with vN.N
+  ],
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true
+    }
+  }
+}

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -2,6 +2,7 @@
 <configuration>
   <packageSources>
     <add key="Build Packages" value="https://www.myget.org/F/c037199d-41df-4567-b966-25ff65324688/api/v3/index.json" />
+    <add key="NBGV CI" value="https://ci.appveyor.com/nuget/nerdbank-gitversioning" />
     <add key="CI Builds (xunit)" value="https://www.myget.org/F/xunit/" />
     <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>

--- a/Rx.NET/Source/Directory.build.props
+++ b/Rx.NET/Source/Directory.build.props
@@ -1,12 +1,10 @@
-<Project>  
-  
+<Project>    
   <PropertyGroup>
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
     <Copyright>Copyright (c) .NET Foundation and Contributors.</Copyright>
     <MinClientVersion>2.12</MinClientVersion>
     <GenerateDocumentationFile Condition=" '$(Configuration)' == 'Release' ">true</GenerateDocumentationFile>
     <Authors>.NET Foundation and Contributors</Authors>
-    <UseFullSemVerForNuGet>true</UseFullSemVerForNuGet>
     <PackageIconUrl>http://go.microsoft.com/fwlink/?LinkId=261274</PackageIconUrl>
     <PackageProjectUrl>http://go.microsoft.com/fwlink/?LinkId=261273</PackageProjectUrl>
     <PackageLicenseUrl>http://go.microsoft.com/fwlink/?LinkID=261272</PackageLicenseUrl>
@@ -16,14 +14,11 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)ReactiveX.snk</AssemblyOriginatorKeyFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>
     <DefaultLanguage>en-US</DefaultLanguage>
-    <WriteVersionInfoToBuildLog>false</WriteVersionInfoToBuildLog>
     <IncludeSymbols>false</IncludeSymbols>
     <IsTestProject>$(MSBuildProjectName.Contains('Test'))</IsTestProject>
-    <GetVersion Condition=" '$(NCrunch)' != '' ">false</GetVersion>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="GitVersionTask" Version="4.0.0-beta0011" PrivateAssets="All" /> 
     <PackageReference Include="MSBuild.Sdk.Extras" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
   
@@ -34,17 +29,21 @@
   <!-- Workaround -->
   <Target Name="GetPackagingOutputs" />
   
-  <!-- https://github.com/NuGet/Home/issues/4337 -->
- <PropertyGroup>
-    <GitVersionTaskVersion>4.0.0-beta0011</GitVersionTaskVersion>
+  <PropertyGroup>
+    <NerdbankGitVersioningVersion>2.0.3-beta-g4d80666c50</NerdbankGitVersioningVersion>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.0.3-beta-g4d80666c50" PrivateAssets="all" />
+  </ItemGroup>
 
+  <!-- https://github.com/NuGet/Home/issues/4337 -->
   <ImportGroup Condition=" '$(ExcludeRestorePackageImports)' == 'true' ">
-    <Import Project="$(UserProfile)\.nuget\packages\GitVersionTask\$(GitVersionTaskVersion)\buildMultiTargeting\GitVersionTask.targets"
-            Condition="Exists('$(UserProfile)\.nuget\packages\GitVersionTask\$(GitVersionTaskVersion)\buildMultiTargeting\GitVersionTask.targets')" />
+    <Import Project="$(UserProfile)\.nuget\packages\nerdbank.gitversioning\$(NerdbankGitVersioningVersion)\buildCrossTargeting\Nerdbank.GitVersioning.targets"
+            Condition="Exists('$(UserProfile)\.nuget\packages\nerdbank.gitversioning\$(NerdbankGitVersioningVersion)\buildCrossTargeting\Nerdbank.GitVersioning.targets')" />
   </ImportGroup>
-  <Target Name="FixupVersion"
+  <Target Name="FixUpVersion"
       BeforeTargets="_GenerateRestoreProjectSpec"
-      DependsOnTargets="GetVersion"
-      Condition=" '$(GitVersion_Task_targets_Imported)' == 'True' " />
+      DependsOnTargets="GetBuildVersion"
+      Condition=" '$(NerdbankGitVersioningTasksPath)' != '' " />
 </Project>

--- a/Rx.NET/Source/NuGet.Config
+++ b/Rx.NET/Source/NuGet.Config
@@ -2,8 +2,8 @@
 <configuration>
   <packageSources>
     <add key="xUnit CI" value="https://www.myget.org/F/xunit/api/v3/index.json" />
+    <add key="NBGV CI" value="https://ci.appveyor.com/nuget/nerdbank-gitversioning" />
     <add key="Build Packages" value="https://www.myget.org/F/c037199d-41df-4567-b966-25ff65324688/api/v3/index.json" />
     <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
-    <!-- <add key="sourcelink" value="https://ci.appveyor.com/nuget/sourcelink/" /> -->
   </packageSources>
 </configuration>

--- a/Rx.NET/Source/build-new.ps1
+++ b/Rx.NET/Source/build-new.ps1
@@ -30,18 +30,18 @@ if (!(Test-Path .\nuget.exe)) {
 # get tools
 .\nuget.exe install -excludeversion SignClient -Version 0.7.0 -outputdirectory packages
 .\nuget.exe install -excludeversion JetBrains.dotCover.CommandLineTools -pre -outputdirectory packages
-.\nuget.exe install -excludeversion gitversion.commandline -pre -outputdirectory packages
+.\nuget.exe install -excludeversion Nerdbank.GitVersioning -Version 2.0.3-beta-g4d80666c50 -pre -outputdirectory packages
 .\nuget.exe install -excludeversion xunit.runner.console -pre -outputdirectory packages
 #.\nuget.exe install -excludeversion OpenCover -Version 4.6.519 -outputdirectory packages
 .\nuget.exe install -excludeversion ReportGenerator -outputdirectory packages
 #.\nuget.exe install -excludeversion coveralls.io -outputdirectory packages
 .\nuget.exe install -excludeversion coveralls.io.dotcover -outputdirectory packages
 
-
 #update version
-.\packages\gitversion.commandline\tools\gitversion.exe /l console /output buildserver
-$versionObj = .\packages\gitversion.commandline\tools\gitversion.exe | ConvertFrom-Json
-$packageSemVer = $versionObj.FullSemVer
+$versionObj = .\packages\Nerdbank.GitVersioning\tools\get-version.ps1
+$packageSemVer = $versionObj.NuGetPackageVersion
+
+Write-Host "Building $packageSemVer" -Foreground Green
 
 New-Item -ItemType Directory -Force -Path $artifacts
 

--- a/Rx.NET/Source/facades/Directory.build.props
+++ b/Rx.NET/Source/facades/Directory.build.props
@@ -2,6 +2,7 @@
   <Import Project="..\Directory.build.props" />
   <PropertyGroup>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyVersionInfo>false</GenerateAssemblyVersionInfo>
     <CopyLocalLockFileAssemblies>false</CopyLocalLockFileAssemblies>
     <Description>Reactive Extensions (Rx) for .NET - v3 compatibility facade for $(AssemblyName)</Description>
   </PropertyGroup>

--- a/Rx.NET/Source/version.json
+++ b/Rx.NET/Source/version.json
@@ -1,0 +1,13 @@
+{
+  "version": "4.0.0-preview.{height}",
+  "publicReleaseRefSpec": [
+    "^refs/heads/master$", // we release out of master
+    "^refs/heads/develop$", // we release out of develop
+    "^refs/tags/v\\d+\\.\\d+" // we also release tags starting with vN.N
+  ],
+  "cloudBuild": {
+    "buildNumber": {
+      "enabled": true
+    }
+  }
+}


### PR DESCRIPTION
This task supports two features we need:

1. different versions per project, Ix and Rx.
2. supports dotnet cli and removes the msbuild requirement.