### PR TITLE
Update Obsolete message for Scheduler

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Internal/Constants.cs
+++ b/Rx.NET/Source/src/System.Reactive/Internal/Constants.cs
@@ -10,8 +10,8 @@ namespace System.Reactive
     {
         private const string OBSOLETE_REFACTORING = "This property is no longer supported due to refactoring of the API surface and elimination of platform-specific dependencies.";
 
-        public const string OBSOLETE_SCHEDULER_NEWTHREAD  = OBSOLETE_REFACTORING + " Please add a reference to the System.Reactive.PlatformServices assembly for your target platform and use NewThreadScheduler.Default to obtain an instance of this scheduler type.";
-        public const string OBSOLETE_SCHEDULER_TASKPOOL   = OBSOLETE_REFACTORING + " Please add a reference to the System.Reactive.PlatformServices assembly for your target platform and use TaskPoolScheduler.Default to obtain an instance of this scheduler type.";
+        public const string OBSOLETE_SCHEDULER_NEWTHREAD  = OBSOLETE_REFACTORING + " Please use NewThreadScheduler.Default to obtain an instance of this scheduler type.";
+        public const string OBSOLETE_SCHEDULER_TASKPOOL   = OBSOLETE_REFACTORING + " Please use TaskPoolScheduler.Default to obtain an instance of this scheduler type.";
         public const string OBSOLETE_SCHEDULER_THREADPOOL = OBSOLETE_REFACTORING + " Consider using Scheduler.Default to obtain the platform's most appropriate pool-based scheduler. In order to access a specific pool-based scheduler, please add a reference to the System.Reactive.PlatformServices assembly for your target platform and use the appropriate scheduler in the System.Reactive.Concurrency namespace.";
 
         public const string OBSOLETE_SCHEDULEREQUIRED     = "This instance property is no longer supported. Use CurrentThreadScheduler.IsScheduleRequired instead.";


### PR DESCRIPTION
This removes misleading message of requiring a reference to System.Reactive.PlatformServices, given it is only a facade library from v4.