### PR TITLE
Specify DebugType in directory.build.props

### DIFF
--- a/Ix.NET/Source/Directory.build.props
+++ b/Ix.NET/Source/Directory.build.props
@@ -15,6 +15,7 @@
     <NoWarn>$(NoWarn);1701;1702;CS1591</NoWarn>
     <DefaultLanguage>en-US</DefaultLanguage>
     <IsTestProject>$(MSBuildProjectName.Contains('Test'))</IsTestProject>
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
   
   <ItemGroup Condition="'$(IsTestProject)' != 'true' and '$(SourceLinkEnabled)' != 'false'">

--- a/Ix.NET/Source/System.Interactive.Async.Providers/System.Interactive.Async.Providers.csproj
+++ b/Ix.NET/Source/System.Interactive.Async.Providers/System.Interactive.Async.Providers.csproj
@@ -5,7 +5,6 @@
     <AssemblyTitle>Interactive Extensions - Async Providers Library</AssemblyTitle>
     <TargetFrameworks>net45;netstandard1.0</TargetFrameworks>
     <PackageTags>Ix;Interactive;Extensions;Enumerable;Asynchronous</PackageTags>
-    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Ix.NET/Source/System.Interactive.Async/System.Interactive.Async.csproj
+++ b/Ix.NET/Source/System.Interactive.Async/System.Interactive.Async.csproj
@@ -5,7 +5,6 @@
     <AssemblyTitle>Interactive Extensions - Async Library</AssemblyTitle>
     <TargetFrameworks>net45;net46;netstandard1.0;netstandard1.3</TargetFrameworks>
     <PackageTags>Ix;Interactive;Extensions;Enumerable;Asynchronous</PackageTags>
-    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Ix.NET/Source/System.Interactive.Providers/System.Interactive.Providers.csproj
+++ b/Ix.NET/Source/System.Interactive.Providers/System.Interactive.Providers.csproj
@@ -5,7 +5,6 @@
     <AssemblyTitle>Interactive Extensions - Providers Library</AssemblyTitle>
     <TargetFrameworks>net45;netstandard1.0</TargetFrameworks>
     <PackageTags>Ix;Interactive;Extensions;Enumerable</PackageTags>
-    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Ix.NET/Source/System.Interactive/System.Interactive.csproj
+++ b/Ix.NET/Source/System.Interactive/System.Interactive.csproj
@@ -6,7 +6,6 @@
     <Authors>Microsoft</Authors>
     <TargetFrameworks>net45;netstandard1.0</TargetFrameworks>
     <PackageTags>Ix;Interactive;Extensions;Enumerable</PackageTags>
-    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Rx.NET/Source/Directory.build.targets
+++ b/Rx.NET/Source/Directory.build.targets
@@ -1,9 +1,4 @@
 <Project>
-  <!-- This has to be set in targets as the default props will overwrite -->
-  <PropertyGroup>
-    <DebugType>embedded</DebugType>
-  </PropertyGroup>
-  
   <!-- This props all need to be set in targets as they depend on the values set earlier -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <DefineConstants>$(DefineConstants);NO_CODE_COVERAGE_ATTRIBUTE;HAS_WINRT;PREFER_ASYNC;HAS_TPL46;NO_REMOTING;NO_SERIALIZABLE;CRIPPLED_REFLECTION</DefineConstants>


### PR DESCRIPTION
Enabled by https://github.com/dotnet/sdk/commit/24db8f1c96dc2857fcecce7f274f1aa94f0017f8

This works for me on dotnet 2.1.1