### PR TITLE
Reverse order of locks taken in LocalScheduler.SystemClockChanged. Po…

### DIFF
--- a/Rx.NET/Source/src/System.Reactive/Concurrency/LocalScheduler.TimerQueue.cs
+++ b/Rx.NET/Source/src/System.Reactive/Concurrency/LocalScheduler.TimerQueue.cs
@@ -369,9 +369,9 @@ namespace System.Reactive.Concurrency
         /// <param name="sender">Currently not used.</param>
         internal void SystemClockChanged(object sender, SystemClockChangedEventArgs args)
         {
-            lock (_gate)
+            lock (s_gate)
             {
-                lock (s_gate)
+                lock (_gate)
                 {
                     //
                     // Best-effort cancellation of short term work. A check for presence in the hash set


### PR DESCRIPTION
This change should fix issue #400.

My employer has been shipping a build of Rx 3.0 with this fix for almost a year, without any issues.